### PR TITLE
Add Travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,14 @@ go:
   - "1.10"
   - "1.x"
 
+install:
+  - go get -t ./...
+  - go get golang.org/x/lint/golint
+
 script:
   - go test -v ./...
   - .travis/check-formatting.sh
+  - golint --set_exit_status ./...
 
 # In addition to pull requests, always build these branches
 branches:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: go
+go:
+  - "1.8"
+  - "1.10"
+  - "1.x"
+
+# In addition to pull requests, always build these branches
+branches:
+  only:
+    - master

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,10 @@ go:
   - "1.10"
   - "1.x"
 
+script:
+  - go test -v ./...
+  - .travis/check-formatting.sh
+
 # In addition to pull requests, always build these branches
 branches:
   only:

--- a/.travis/check-formatting.sh
+++ b/.travis/check-formatting.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+# Ensure that $PWD is the root of this repository
+SCRIPT_PATH=`dirname $0`
+cd "${SCRIPT_PATH}/.."
+
+if gofmt -l . 2>&1 | read line; then
+  # There were errors.  Re-run gofmt to print them out into the test log.
+  echo "The following files are not formatted correctly according to gofmt:"
+  gofmt -l .
+  exit 1
+fi

--- a/pkg/collector/collector.go
+++ b/pkg/collector/collector.go
@@ -1,0 +1,16 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package collector provides the basics of a NEL-compliant report collector.
+package collector


### PR DESCRIPTION
I chose the list of Go versions to support basically randomly.  I had to add an empty package to make `go test` succeed.