### PR TITLE
Add report processing pipeline

### DIFF
--- a/cmd/nel-collector/main.go
+++ b/cmd/nel-collector/main.go
@@ -1,0 +1,51 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"log"
+	"net/http"
+	"os"
+
+	"github.com/google/nel-collector/pkg/collector"
+)
+
+var rootBody = []byte(`
+<html>
+  <head>
+    <title>Network Error Logging collector</title>
+  </head>
+  <body>
+    <h1>Network Error Logging</h1>
+    <p>
+      This is a collector that can receive
+      <a href="https://wicg.github.io/network-error-logging/">Network Error
+      Logging</a> reports.
+    </p>
+  </body>
+</html>
+`)
+
+func handleRoot(w http.ResponseWriter, r *http.Request) {
+	w.Write(rootBody)
+}
+
+func main() {
+	pipeline := &collector.Pipeline{}
+	pipeline.AddProcessor(collector.ReportDumper{os.Stdout})
+	http.HandleFunc("/", handleRoot)
+	http.Handle("/upload/", pipeline)
+	log.Fatal(http.ListenAndServe(":8080", nil))
+}

--- a/pkg/collector/pipeline.go
+++ b/pkg/collector/pipeline.go
@@ -1,0 +1,92 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package collector
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+)
+
+// ReportBatch is a collection of reports that should all be processed together.
+// We will create a new batch for each upload that the collector receives.
+// Certain processors might join batches together or split them up.
+type ReportBatch struct {
+	Reports []NelReport
+}
+
+// A ReportProcessor implements one discrete processing step for handling
+// uploaded reports.  There are several predefined processors, which you can use
+// to filter or publish reports.  You can also implement custom annotation steps
+// if you want to add additional data to a report before publishing.
+type ReportProcessor interface {
+	// ProcessReports handles a single batch of reports.  You have full control
+	// over the contents of the batch; for instance, you can remove elements or
+	// update their contents, if appropriate.
+	ProcessReports(batch *ReportBatch)
+}
+
+// A ReportDumper is a ReportProcessor that prints out a summary of each report.
+type ReportDumper struct {
+	Writer io.Writer
+}
+
+// ProcessReports prints out a summary of each report in the batch.
+func (d ReportDumper) ProcessReports(batch *ReportBatch) {
+	for _, report := range batch.Reports {
+		fmt.Fprintf(d.Writer, "[%s] %s\n", report.Type, report.URL)
+	}
+}
+
+// Pipeline is a series of processors that should be applied to each report that
+// the collector receives.
+type Pipeline struct {
+	processors []ReportProcessor
+}
+
+// AddProcessor adds a new processor to the pipeline.
+func (p *Pipeline) AddProcessor(processor ReportProcessor) {
+	p.processors = append(p.processors, processor)
+}
+
+// ServeHTTP listens for POSTed report uploads, as defined by the Reporting
+// spec, and runs all of the processors in the pipeline against each report.
+func (p *Pipeline) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.Method != "POST" {
+		http.Error(w, "Must use POST to upload reports", http.StatusMethodNotAllowed)
+		return
+	}
+
+	contentType := r.Header.Get("Content-Type")
+	if contentType != "application/report" {
+		http.Error(w, "Must use application/report to upload reports", http.StatusBadRequest)
+		return
+	}
+
+	var reports ReportBatch
+	decoder := json.NewDecoder(r.Body)
+	err := decoder.Decode(&reports.Reports)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	for _, publisher := range p.processors {
+		publisher.ProcessReports(&reports)
+	}
+	// 204 isn't an error, per-se, but this does the right thing.
+	http.Error(w, "", http.StatusNoContent)
+}

--- a/pkg/collector/pipeline.go
+++ b/pkg/collector/pipeline.go
@@ -47,7 +47,11 @@ type ReportDumper struct {
 // ProcessReports prints out a summary of each report in the batch.
 func (d ReportDumper) ProcessReports(batch *ReportBatch) {
 	for _, report := range batch.Reports {
-		fmt.Fprintf(d.Writer, "[%s] %s\n", report.Type, report.URL)
+		if report.ReportType == "network-error" {
+			fmt.Fprintf(d.Writer, "[%s] %s\n", report.Type, report.URL)
+		} else {
+			fmt.Fprintf(d.Writer, "<%s> %s\n", report.ReportType, report.URL)
+		}
 	}
 }
 

--- a/pkg/collector/pipeline_test.go
+++ b/pkg/collector/pipeline_test.go
@@ -1,0 +1,104 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package collector
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+var validNELReport = []byte(`[
+		  {
+		    "age": 500,
+		    "type": "network-error",
+		    "url": "https://example.com/about/",
+		    "body": {
+		      "uri": "https://example.com/about/",
+		      "referrer": "https://example.com/",
+		      "sampling-fraction": 0.5,
+		      "server-ip": "203.0.113.75",
+		      "protocol": "h2",
+		      "status-code": 200,
+		      "elapsed-time": 45,
+		      "type": "ok"
+		    }
+		  }
+		]`)
+
+func TestIgnoreNonPOST(t *testing.T) {
+	pipeline := &Pipeline{}
+	request := httptest.NewRequest("GET", "https://example.com/upload/", bytes.NewReader(validNELReport))
+	request.Header.Add("Content-Type", "application/report")
+	var response httptest.ResponseRecorder
+	pipeline.ServeHTTP(&response, request)
+	if response.Code != http.StatusMethodNotAllowed {
+		t.Errorf("ServeHTTP(GET): got %d, wanted %d", response.Code, http.StatusMethodNotAllowed)
+		return
+	}
+}
+
+func TestIgnoreWrongContentType(t *testing.T) {
+	pipeline := &Pipeline{}
+	request := httptest.NewRequest("POST", "https://example.com/upload/", bytes.NewReader(validNELReport))
+	request.Header.Add("Content-Type", "application/json")
+	var response httptest.ResponseRecorder
+	pipeline.ServeHTTP(&response, request)
+	if response.Code != http.StatusBadRequest {
+		t.Errorf("ServeHTTP(GET): got %d, wanted %d", response.Code, http.StatusBadRequest)
+		return
+	}
+}
+
+var dumpCases = []struct {
+	name   string
+	json   []byte
+	dumped []byte
+}{
+	{
+		"ValidNELReport",
+		validNELReport,
+		[]byte("[ok] https://example.com/about/\n"),
+	},
+}
+
+func TestDumpReports(t *testing.T) {
+	for _, c := range dumpCases {
+		t.Run("Dump:"+c.name, func(t *testing.T) {
+			pipeline := &Pipeline{}
+			var buffer bytes.Buffer
+			pipeline.AddProcessor(ReportDumper{&buffer})
+
+			request := httptest.NewRequest("POST", "https://example.com/upload/", bytes.NewReader(c.json))
+			request.Header.Add("Content-Type", "application/report")
+			var response httptest.ResponseRecorder
+			pipeline.ServeHTTP(&response, request)
+
+			if response.Code != http.StatusNoContent {
+				t.Errorf("ServeHTTP(%s): got %d, wanted %d", compactJSON(c.json), response.Code, http.StatusNoContent)
+				return
+			}
+
+			got := buffer.Bytes()
+			if !cmp.Equal(got, c.dumped) {
+				t.Errorf("ReportDumper(%s) == %s, wanted %s", compactJSON(c.json), got, c.dumped)
+				return
+			}
+		})
+	}
+}

--- a/pkg/collector/pipeline_test.go
+++ b/pkg/collector/pipeline_test.go
@@ -41,6 +41,15 @@ var validNELReport = []byte(`[
 		  }
 		]`)
 
+var nonNELReport = []byte(`[
+		  {
+		    "age": 500,
+		    "type": "another-error",
+		    "url": "https://example.com/about/",
+		    "body": {"random": "stuff", "ignore": 100}
+		  }
+		]`)
+
 func TestIgnoreNonPOST(t *testing.T) {
 	pipeline := &Pipeline{}
 	request := httptest.NewRequest("GET", "https://example.com/upload/", bytes.NewReader(validNELReport))
@@ -74,6 +83,11 @@ var dumpCases = []struct {
 		"ValidNELReport",
 		validNELReport,
 		[]byte("[ok] https://example.com/about/\n"),
+	},
+	{
+		"NonNELReport",
+		nonNELReport,
+		[]byte("<another-error> https://example.com/about/\n"),
 	},
 }
 


### PR DESCRIPTION
This is the meat of the collector: an HTTP handler that listens for POST uploads, and parses the JSON array of reports in the payload.  The generic ReportProcessor interface will allow us to customize and configure how exactly the reports are handled.  Right now, there aren't any interesting processors, but eventually we'll add some filters and a variety of output processors for publishing the reports to external logging or monitoring systems.

This patch also adds a `nel-collector` command.  It's currently not configurable; it listens on localhost:8080 and prints out a summary of each report to stdout.  Eventually it will be much more interesting.