### PR TITLE
Add times to report batches

### DIFF
--- a/cmd/nel-collector/main.go
+++ b/cmd/nel-collector/main.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// nel-collector runs a NEL collector on port 8080, printing out a summary of
+// each report that it receives.
 package main
 
 import (


### PR DESCRIPTION
We now add a timestamp to each report batch (not to individual reports).  This timestamp reflects when the batch was received by the collector.  That timestamp, minus the `age` of each report, gives an estimate of
when the report was generated.