### PR TITLE
Add client IP and user-agent to report batches

### DIFF
--- a/pkg/collector/pipeline_test.go
+++ b/pkg/collector/pipeline_test.go
@@ -95,12 +95,12 @@ var dumpCases = []struct {
 	{
 		"ValidNELReport",
 		validNELReport,
-		[]byte("1970-01-01 00:00:00.000 [ok] https://example.com/about/\n"),
+		[]byte("192.0.2.1 - - [01/Jan/1970:00:00:00.000 +0000] \"GET https://example.com/about/\" 200 -\n"),
 	},
 	{
 		"NonNELReport",
 		nonNELReport,
-		[]byte("1970-01-01 00:00:00.000 <another-error> https://example.com/about/\n"),
+		[]byte("192.0.2.1 - - [01/Jan/1970:00:00:00.000 +0000] \"GET https://example.com/about/\" <another-error> -\n"),
 	},
 }
 


### PR DESCRIPTION
Just like collection time, this information only needs to be recorded for batches, not for the individual reports within a batch.

This also gives us all the information we need to make the report dumper use Apache's CLF format.  Er, well, _almost_ all the information; we should probably update the spec to include the HTTP verb...