### PR TITLE
Throw away non-NEL reports

### DIFF
--- a/cmd/nel-collector/main.go
+++ b/cmd/nel-collector/main.go
@@ -17,12 +17,15 @@
 package main
 
 import (
+	"flag"
 	"log"
 	"net/http"
 	"os"
 
 	"github.com/google/nel-collector/pkg/collector"
 )
+
+var keepNonNelReports = flag.Bool("keep-non-nel-reports", false, "keep non-NEL reports")
 
 var rootBody = []byte(`
 <html>
@@ -46,6 +49,9 @@ func handleRoot(w http.ResponseWriter, r *http.Request) {
 
 func main() {
 	pipeline := &collector.Pipeline{}
+	if !*keepNonNelReports {
+		pipeline.AddProcessor(&collector.KeepNelReports{})
+	}
 	pipeline.AddProcessor(collector.ReportDumper{os.Stdout})
 	http.HandleFunc("/", handleRoot)
 	http.Handle("/upload/", pipeline)

--- a/pkg/collector/filter.go
+++ b/pkg/collector/filter.go
@@ -1,0 +1,28 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package collector
+
+// KeepNelReports is a pipeline processor that throws away any non-NEL reports.
+type KeepNelReports struct{}
+
+func (_ KeepNelReports) ProcessReports(batch *ReportBatch) {
+	var filtered []NelReport
+	for _, report := range batch.Reports {
+		if report.ReportType == "network-error" {
+			filtered = append(filtered, report)
+		}
+	}
+	batch.Reports = filtered
+}

--- a/pkg/collector/filter_test.go
+++ b/pkg/collector/filter_test.go
@@ -1,0 +1,46 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package collector
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestKeepNelReports(t *testing.T) {
+	for _, p := range allPipelineTests() {
+		t.Run("KeepNelReports:"+p.fullname(), func(t *testing.T) {
+			var batch ReportBatch
+			p.pipeline.AddProcessor(&KeepNelReports{})
+			p.pipeline.AddProcessor(&stashReports{&batch})
+			if !p.handleRequest(t) {
+				return
+			}
+
+			got, err := encodeRawBatch(batch)
+			if err != nil {
+				t.Errorf("encodeRawBatch(%s): %v", p.fullname(), err)
+				return
+			}
+
+			want := goldendata(t, p.ipdataName(".keep-nel.json"), got)
+			if !cmp.Equal(got, want) {
+				t.Errorf("ReportDumper(%s) == %s, wanted %s", p.fullname(), got, want)
+				return
+			}
+		})
+	}
+}

--- a/pkg/collector/testdata/multiple-valid-nel-reports.ipv4.keep-nel.json
+++ b/pkg/collector/testdata/multiple-valid-nel-reports.ipv4.keep-nel.json
@@ -1,0 +1,36 @@
+{
+  "Time": "1970-01-01T00:00:00Z",
+  "ClientIP": "192.0.2.1",
+  "ClientUserAgent": "",
+  "Annotation": null,
+  "Reports": [
+    {
+      "Age": 500,
+      "ReportType": "network-error",
+      "URL": "https://example.com/about/",
+      "Referrer": "https://example.com/",
+      "SamplingFraction": 0.5,
+      "ServerIP": "203.0.113.75",
+      "Protocol": "h2",
+      "StatusCode": 200,
+      "ElapsedTime": 45,
+      "Type": "ok",
+      "RawBody": null,
+      "Annotation": null
+    },
+    {
+      "Age": 500,
+      "ReportType": "network-error",
+      "URL": "https://example.com/login/",
+      "Referrer": "https://example.com/",
+      "SamplingFraction": 0.5,
+      "ServerIP": "203.0.113.76",
+      "Protocol": "h2",
+      "StatusCode": 200,
+      "ElapsedTime": 45,
+      "Type": "ok",
+      "RawBody": null,
+      "Annotation": null
+    }
+  ]
+}

--- a/pkg/collector/testdata/multiple-valid-nel-reports.ipv6.keep-nel.json
+++ b/pkg/collector/testdata/multiple-valid-nel-reports.ipv6.keep-nel.json
@@ -1,0 +1,36 @@
+{
+  "Time": "1970-01-01T00:00:00Z",
+  "ClientIP": "2001:db8::2",
+  "ClientUserAgent": "",
+  "Annotation": null,
+  "Reports": [
+    {
+      "Age": 500,
+      "ReportType": "network-error",
+      "URL": "https://example.com/about/",
+      "Referrer": "https://example.com/",
+      "SamplingFraction": 0.5,
+      "ServerIP": "203.0.113.75",
+      "Protocol": "h2",
+      "StatusCode": 200,
+      "ElapsedTime": 45,
+      "Type": "ok",
+      "RawBody": null,
+      "Annotation": null
+    },
+    {
+      "Age": 500,
+      "ReportType": "network-error",
+      "URL": "https://example.com/login/",
+      "Referrer": "https://example.com/",
+      "SamplingFraction": 0.5,
+      "ServerIP": "203.0.113.76",
+      "Protocol": "h2",
+      "StatusCode": 200,
+      "ElapsedTime": 45,
+      "Type": "ok",
+      "RawBody": null,
+      "Annotation": null
+    }
+  ]
+}

--- a/pkg/collector/testdata/non-nel-report.ipv4.keep-nel.json
+++ b/pkg/collector/testdata/non-nel-report.ipv4.keep-nel.json
@@ -1,0 +1,7 @@
+{
+  "Time": "1970-01-01T00:00:00Z",
+  "ClientIP": "192.0.2.1",
+  "ClientUserAgent": "",
+  "Annotation": null,
+  "Reports": []
+}

--- a/pkg/collector/testdata/non-nel-report.ipv6.keep-nel.json
+++ b/pkg/collector/testdata/non-nel-report.ipv6.keep-nel.json
@@ -1,0 +1,7 @@
+{
+  "Time": "1970-01-01T00:00:00Z",
+  "ClientIP": "2001:db8::2",
+  "ClientUserAgent": "",
+  "Annotation": null,
+  "Reports": []
+}

--- a/pkg/collector/testdata/valid-nel-report.ipv4.keep-nel.json
+++ b/pkg/collector/testdata/valid-nel-report.ipv4.keep-nel.json
@@ -1,0 +1,22 @@
+{
+  "Time": "1970-01-01T00:00:00Z",
+  "ClientIP": "192.0.2.1",
+  "ClientUserAgent": "",
+  "Annotation": null,
+  "Reports": [
+    {
+      "Age": 500,
+      "ReportType": "network-error",
+      "URL": "https://example.com/about/",
+      "Referrer": "https://example.com/",
+      "SamplingFraction": 0.5,
+      "ServerIP": "203.0.113.75",
+      "Protocol": "h2",
+      "StatusCode": 200,
+      "ElapsedTime": 45,
+      "Type": "ok",
+      "RawBody": null,
+      "Annotation": null
+    }
+  ]
+}

--- a/pkg/collector/testdata/valid-nel-report.ipv6.keep-nel.json
+++ b/pkg/collector/testdata/valid-nel-report.ipv6.keep-nel.json
@@ -1,0 +1,22 @@
+{
+  "Time": "1970-01-01T00:00:00Z",
+  "ClientIP": "2001:db8::2",
+  "ClientUserAgent": "",
+  "Annotation": null,
+  "Reports": [
+    {
+      "Age": 500,
+      "ReportType": "network-error",
+      "URL": "https://example.com/about/",
+      "Referrer": "https://example.com/",
+      "SamplingFraction": 0.5,
+      "ServerIP": "203.0.113.75",
+      "Protocol": "h2",
+      "StatusCode": 200,
+      "ElapsedTime": 45,
+      "Type": "ok",
+      "RawBody": null,
+      "Annotation": null
+    }
+  ]
+}


### PR DESCRIPTION
This patch adds a new pipeline processor that throws away any non-NEL reports that are received.  The new `--keep-non-nel-reports` command-line flag controls whether the predefined server does anything with non-NEL reports; the default is to drop them.