### PR TITLE
Include collector URL in report batch

### DIFF
--- a/pkg/collector/pipeline.go
+++ b/pkg/collector/pipeline.go
@@ -20,6 +20,7 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"net/url"
 	"strconv"
 	"time"
 )
@@ -32,6 +33,9 @@ type ReportBatch struct {
 
 	// When this batch was received by the collector
 	Time time.Time
+
+	// The URL that was used to upload the report.
+	CollectorURL url.URL
 
 	// The IP address of the client that uploaded the batch of reports.  You can
 	// typically assume that's the same IP address that was used for the original
@@ -141,6 +145,7 @@ func (p *Pipeline) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	var reports ReportBatch
 	reports.Time = clock.Now()
+	reports.CollectorURL = *r.URL
 	reports.ClientIP = host
 	reports.ClientUserAgent = r.Header.Get("User-Agent")
 	decoder := json.NewDecoder(r.Body)

--- a/pkg/collector/testdata/multiple-valid-nel-reports.ipv4.annotated.json
+++ b/pkg/collector/testdata/multiple-valid-nel-reports.ipv4.annotated.json
@@ -1,5 +1,16 @@
 {
   "Time": "1970-01-01T00:00:00Z",
+  "CollectorURL": {
+    "Scheme": "https",
+    "Opaque": "",
+    "User": null,
+    "Host": "example.com",
+    "Path": "/upload/",
+    "RawPath": "",
+    "ForceQuery": false,
+    "RawQuery": "",
+    "Fragment": ""
+  },
   "ClientIP": "192.0.2.1",
   "ClientUserAgent": "",
   "Annotation": "US",

--- a/pkg/collector/testdata/multiple-valid-nel-reports.ipv4.processed.json
+++ b/pkg/collector/testdata/multiple-valid-nel-reports.ipv4.processed.json
@@ -1,5 +1,16 @@
 {
   "Time": "1970-01-01T00:00:00Z",
+  "CollectorURL": {
+    "Scheme": "https",
+    "Opaque": "",
+    "User": null,
+    "Host": "example.com",
+    "Path": "/upload/",
+    "RawPath": "",
+    "ForceQuery": false,
+    "RawQuery": "",
+    "Fragment": ""
+  },
   "ClientIP": "192.0.2.1",
   "ClientUserAgent": "",
   "Annotation": null,

--- a/pkg/collector/testdata/multiple-valid-nel-reports.ipv6.annotated.json
+++ b/pkg/collector/testdata/multiple-valid-nel-reports.ipv6.annotated.json
@@ -1,5 +1,16 @@
 {
   "Time": "1970-01-01T00:00:00Z",
+  "CollectorURL": {
+    "Scheme": "https",
+    "Opaque": "",
+    "User": null,
+    "Host": "example.com",
+    "Path": "/upload/",
+    "RawPath": "",
+    "ForceQuery": false,
+    "RawQuery": "",
+    "Fragment": ""
+  },
   "ClientIP": "2001:db8::2",
   "ClientUserAgent": "",
   "Annotation": "",

--- a/pkg/collector/testdata/multiple-valid-nel-reports.ipv6.processed.json
+++ b/pkg/collector/testdata/multiple-valid-nel-reports.ipv6.processed.json
@@ -1,5 +1,16 @@
 {
   "Time": "1970-01-01T00:00:00Z",
+  "CollectorURL": {
+    "Scheme": "https",
+    "Opaque": "",
+    "User": null,
+    "Host": "example.com",
+    "Path": "/upload/",
+    "RawPath": "",
+    "ForceQuery": false,
+    "RawQuery": "",
+    "Fragment": ""
+  },
   "ClientIP": "2001:db8::2",
   "ClientUserAgent": "",
   "Annotation": null,

--- a/pkg/collector/testdata/non-nel-report.ipv4.annotated.json
+++ b/pkg/collector/testdata/non-nel-report.ipv4.annotated.json
@@ -1,5 +1,16 @@
 {
   "Time": "1970-01-01T00:00:00Z",
+  "CollectorURL": {
+    "Scheme": "https",
+    "Opaque": "",
+    "User": null,
+    "Host": "example.com",
+    "Path": "/upload/",
+    "RawPath": "",
+    "ForceQuery": false,
+    "RawQuery": "",
+    "Fragment": ""
+  },
   "ClientIP": "192.0.2.1",
   "ClientUserAgent": "",
   "Annotation": "US",

--- a/pkg/collector/testdata/non-nel-report.ipv4.processed.json
+++ b/pkg/collector/testdata/non-nel-report.ipv4.processed.json
@@ -1,5 +1,16 @@
 {
   "Time": "1970-01-01T00:00:00Z",
+  "CollectorURL": {
+    "Scheme": "https",
+    "Opaque": "",
+    "User": null,
+    "Host": "example.com",
+    "Path": "/upload/",
+    "RawPath": "",
+    "ForceQuery": false,
+    "RawQuery": "",
+    "Fragment": ""
+  },
   "ClientIP": "192.0.2.1",
   "ClientUserAgent": "",
   "Annotation": null,

--- a/pkg/collector/testdata/non-nel-report.ipv6.annotated.json
+++ b/pkg/collector/testdata/non-nel-report.ipv6.annotated.json
@@ -1,5 +1,16 @@
 {
   "Time": "1970-01-01T00:00:00Z",
+  "CollectorURL": {
+    "Scheme": "https",
+    "Opaque": "",
+    "User": null,
+    "Host": "example.com",
+    "Path": "/upload/",
+    "RawPath": "",
+    "ForceQuery": false,
+    "RawQuery": "",
+    "Fragment": ""
+  },
   "ClientIP": "2001:db8::2",
   "ClientUserAgent": "",
   "Annotation": "",

--- a/pkg/collector/testdata/non-nel-report.ipv6.processed.json
+++ b/pkg/collector/testdata/non-nel-report.ipv6.processed.json
@@ -1,5 +1,16 @@
 {
   "Time": "1970-01-01T00:00:00Z",
+  "CollectorURL": {
+    "Scheme": "https",
+    "Opaque": "",
+    "User": null,
+    "Host": "example.com",
+    "Path": "/upload/",
+    "RawPath": "",
+    "ForceQuery": false,
+    "RawQuery": "",
+    "Fragment": ""
+  },
   "ClientIP": "2001:db8::2",
   "ClientUserAgent": "",
   "Annotation": null,

--- a/pkg/collector/testdata/valid-nel-report.ipv4.annotated.json
+++ b/pkg/collector/testdata/valid-nel-report.ipv4.annotated.json
@@ -1,5 +1,16 @@
 {
   "Time": "1970-01-01T00:00:00Z",
+  "CollectorURL": {
+    "Scheme": "https",
+    "Opaque": "",
+    "User": null,
+    "Host": "example.com",
+    "Path": "/upload/",
+    "RawPath": "",
+    "ForceQuery": false,
+    "RawQuery": "",
+    "Fragment": ""
+  },
   "ClientIP": "192.0.2.1",
   "ClientUserAgent": "",
   "Annotation": "US",

--- a/pkg/collector/testdata/valid-nel-report.ipv4.processed.json
+++ b/pkg/collector/testdata/valid-nel-report.ipv4.processed.json
@@ -1,5 +1,16 @@
 {
   "Time": "1970-01-01T00:00:00Z",
+  "CollectorURL": {
+    "Scheme": "https",
+    "Opaque": "",
+    "User": null,
+    "Host": "example.com",
+    "Path": "/upload/",
+    "RawPath": "",
+    "ForceQuery": false,
+    "RawQuery": "",
+    "Fragment": ""
+  },
   "ClientIP": "192.0.2.1",
   "ClientUserAgent": "",
   "Annotation": null,

--- a/pkg/collector/testdata/valid-nel-report.ipv6.annotated.json
+++ b/pkg/collector/testdata/valid-nel-report.ipv6.annotated.json
@@ -1,5 +1,16 @@
 {
   "Time": "1970-01-01T00:00:00Z",
+  "CollectorURL": {
+    "Scheme": "https",
+    "Opaque": "",
+    "User": null,
+    "Host": "example.com",
+    "Path": "/upload/",
+    "RawPath": "",
+    "ForceQuery": false,
+    "RawQuery": "",
+    "Fragment": ""
+  },
   "ClientIP": "2001:db8::2",
   "ClientUserAgent": "",
   "Annotation": "",

--- a/pkg/collector/testdata/valid-nel-report.ipv6.processed.json
+++ b/pkg/collector/testdata/valid-nel-report.ipv6.processed.json
@@ -1,5 +1,16 @@
 {
   "Time": "1970-01-01T00:00:00Z",
+  "CollectorURL": {
+    "Scheme": "https",
+    "Opaque": "",
+    "User": null,
+    "Host": "example.com",
+    "Path": "/upload/",
+    "RawPath": "",
+    "ForceQuery": false,
+    "RawQuery": "",
+    "Fragment": ""
+  },
   "ClientIP": "2001:db8::2",
   "ClientUserAgent": "",
   "Annotation": null,


### PR DESCRIPTION
This lets you encode information in the collector URLs — for instance, to link reports to particular services.