### PR TITLE
Move TestPipeline into a public helper package

### DIFF
--- a/pkg/collector/filter_test.go
+++ b/pkg/collector/filter_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/nel-collector/pkg/collector"
+	"github.com/google/nel-collector/pkg/pipelinetest"
 )
 
 func TestKeepNelReports(t *testing.T) {
@@ -26,7 +27,7 @@ func TestKeepNelReports(t *testing.T) {
 		t.Run("KeepNelReports:"+p.fullname(), func(t *testing.T) {
 			var batch collector.ReportBatch
 			p.AddProcessor(&collector.KeepNelReports{})
-			p.AddProcessor(&stashReports{&batch})
+			p.AddProcessor(&pipelinetest.StashReports{&batch})
 			err := p.HandleRequest(t, testdata(t, p.testdataName(".json")))
 			if err != nil {
 				t.Errorf("HandleRequest(%s): %v", p.fullname(), err)

--- a/pkg/collector/filter_test.go
+++ b/pkg/collector/filter_test.go
@@ -12,21 +12,24 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package collector
+package collector_test
 
 import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/nel-collector/pkg/collector"
 )
 
 func TestKeepNelReports(t *testing.T) {
 	for _, p := range allPipelineTests() {
 		t.Run("KeepNelReports:"+p.fullname(), func(t *testing.T) {
-			var batch ReportBatch
-			p.pipeline.AddProcessor(&KeepNelReports{})
-			p.pipeline.AddProcessor(&stashReports{&batch})
-			if !p.handleRequest(t) {
+			var batch collector.ReportBatch
+			p.AddProcessor(&collector.KeepNelReports{})
+			p.AddProcessor(&stashReports{&batch})
+			err := p.HandleRequest(t, testdata(t, p.testdataName(".json")))
+			if err != nil {
+				t.Errorf("HandleRequest(%s): %v", p.fullname(), err)
 				return
 			}
 

--- a/pkg/collector/pipeline.go
+++ b/pkg/collector/pipeline.go
@@ -107,9 +107,10 @@ type Pipeline struct {
 	clock      Clock
 }
 
-// NewTestPipeline creates a Pipeline that will use a particular Clock to assign
-// times to each report batch, instead of using time.Now.
-func NewTestPipeline(clock Clock) *Pipeline {
+// NewPipeline creates a new Pipeline that uses a particular clock.  For
+// production pipelines, just instantiate the Pipeline type yourself
+// (&Pipeline{}).
+func NewPipeline(clock Clock) *Pipeline {
 	return &Pipeline{clock: clock}
 }
 

--- a/pkg/collector/pipeline_test.go
+++ b/pkg/collector/pipeline_test.go
@@ -81,19 +81,11 @@ func TestIgnoreWrongContentType(t *testing.T) {
 	}
 }
 
-type stashReports struct {
-	dest *collector.ReportBatch
-}
-
-func (s stashReports) ProcessReports(batch *collector.ReportBatch) {
-	*s.dest = *batch
-}
-
 func TestProcessReports(t *testing.T) {
 	for _, p := range allPipelineTests() {
 		t.Run("Process:"+p.fullname(), func(t *testing.T) {
 			var batch collector.ReportBatch
-			p.AddProcessor(&stashReports{&batch})
+			p.AddProcessor(&pipelinetest.StashReports{&batch})
 			err := p.HandleRequest(t, testdata(t, p.testdataName(".json")))
 			if err != nil {
 				t.Errorf("HandleRequest(%s): %v", p.fullname(), err)
@@ -164,7 +156,7 @@ func TestCustomAnnotation(t *testing.T) {
 		t.Run("Annotate:"+p.fullname(), func(t *testing.T) {
 			var batch collector.ReportBatch
 			p.AddProcessor(&geoAnnotator{})
-			p.AddProcessor(&stashReports{&batch})
+			p.AddProcessor(&pipelinetest.StashReports{&batch})
 			err := p.HandleRequest(t, testdata(t, p.testdataName(".json")))
 			if err != nil {
 				t.Errorf("HandleRequest(%s): %v", p.fullname(), err)

--- a/pkg/collector/report_test.go
+++ b/pkg/collector/report_test.go
@@ -12,13 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package collector
+package collector_test
 
 import (
 	"encoding/json"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/nel-collector/pkg/collector"
 )
 
 // JSON marshalling and unmarshalling
@@ -34,7 +35,7 @@ func TestNelReport(t *testing.T) {
 			parsedFile := name + ".parsed.json"
 			jsonData := testdata(t, jsonFile)
 
-			var reports []NelReport
+			var reports []collector.NelReport
 			err := json.Unmarshal(jsonData, &reports)
 			if err != nil {
 				t.Errorf("json.Unmarshal(%s): %v", name, err)
@@ -61,7 +62,7 @@ func TestNelReport(t *testing.T) {
 			parsedFile := name + ".parsed.json"
 			parsedData := testdata(t, parsedFile)
 
-			var reports []NelReport
+			var reports []collector.NelReport
 			err := decodeRawReports(parsedData, &reports)
 			if err != nil {
 				t.Errorf("decodeRawReports(%s): %v", name, err)

--- a/pkg/collector/utils_test.go
+++ b/pkg/collector/utils_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package collector
+package collector_test
 
 import (
 	"bytes"
@@ -21,6 +21,8 @@ import (
 	"io/ioutil"
 	"path/filepath"
 	"testing"
+
+	"github.com/google/nel-collector/pkg/collector"
 )
 
 var update = flag.Bool("update", false, "update .golden files")
@@ -74,10 +76,10 @@ func compactJSON(b []byte) []byte {
 // spec-aware JSON parsing rules, instead dumping out the content exactly as it
 // looks in Go.  This is used extensively in test cases to compare the results
 // of parsing and annotating against golden files.
-func encodeRawReports(reports []NelReport) ([]byte, error) {
+func encodeRawReports(reports []collector.NelReport) ([]byte, error) {
 	// This type alias lets us override our spec-aware JSON parsing rules, and
 	// dump out the content of a NelReport instance exactly as it looks in Go.
-	type ParsedNelReport NelReport
+	type ParsedNelReport collector.NelReport
 	parsedReports := make([]ParsedNelReport, len(reports))
 	for i := range reports {
 		parsedReports[i] = (ParsedNelReport)(reports[i])
@@ -87,29 +89,29 @@ func encodeRawReports(reports []NelReport) ([]byte, error) {
 
 // decodeRawReports unmarshals an array of NelReports without using our custom
 // spec-aware JSON parsing rules.  It's the inverse of encodeRawReports.
-func decodeRawReports(b []byte, reports *[]NelReport) error {
+func decodeRawReports(b []byte, reports *[]collector.NelReport) error {
 	// This type alias lets us override our spec-aware JSON parsing rules, and
 	// dump out the content of a NelReport instance exactly as it looks in Go.
-	type ParsedNelReport NelReport
+	type ParsedNelReport collector.NelReport
 	var parsedReports []ParsedNelReport
 	err := json.Unmarshal(b, &parsedReports)
 	if err != nil {
 		return err
 	}
 
-	*reports = make([]NelReport, len(parsedReports))
+	*reports = make([]collector.NelReport, len(parsedReports))
 	for i := range parsedReports {
-		(*reports)[i] = (NelReport)(parsedReports[i])
+		(*reports)[i] = (collector.NelReport)(parsedReports[i])
 	}
 	return nil
 }
 
 // encodeRawBatch marshals a batch of NelReports, including any custom
 // annotations, without using our custom spec-aware JSON parsing rules.
-func encodeRawBatch(batch ReportBatch) ([]byte, error) {
+func encodeRawBatch(batch collector.ReportBatch) ([]byte, error) {
 	var err error
 	var rawBatch struct {
-		ReportBatch
+		collector.ReportBatch
 		RawReports json.RawMessage `json:"Reports"`
 	}
 

--- a/pkg/pipelinetest/pipelinetest.go
+++ b/pkg/pipelinetest/pipelinetest.go
@@ -1,0 +1,81 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package pipelinetest contains helper utilities for constructing test cases
+// that exercise the components of a NEL collector pipeline.
+package pipelinetest
+
+import (
+	"bytes"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/google/nel-collector/pkg/collector"
+)
+
+type simulatedClock struct {
+	currentTime time.Time
+}
+
+func newSimulatedClock() *simulatedClock {
+	return &simulatedClock{currentTime: time.Unix(0, 0).UTC()}
+}
+
+func (c simulatedClock) Now() time.Time {
+	return c.currentTime
+}
+
+// TestPipeline is a wrapper around Pipeline that is easier to use in test
+// cases.  It uses a simulated clock, giving you reproducible timestamps in test
+// output, and has helper methods for "uploading" a report payload.
+type TestPipeline struct {
+	*collector.Pipeline
+	remoteAddr string
+}
+
+// NewTestPipeline creates a Pipeline that will use a particular Clock to assign
+// times to each report batch, instead of using time.Now.
+func NewTestPipeline(remoteAddr string) *TestPipeline {
+	return &TestPipeline{collector.NewPipeline(newSimulatedClock()), remoteAddr}
+}
+
+// HandleCustomRequest processes a report payload as if it were uploaded using
+// the given HTTP method and MIME type.  This is useful for test cases where you
+// want to verify that uploads that don't conform to the Reporting spec are
+// handled properly.
+func (p *TestPipeline) HandleCustomRequest(t *testing.T, method, mimeType string, payload []byte) *httptest.ResponseRecorder {
+	request := httptest.NewRequest(method, "https://example.com/upload/", bytes.NewReader(payload))
+	request.Header.Add("Content-Type", mimeType)
+	if p.remoteAddr != "" {
+		request.RemoteAddr = p.remoteAddr
+	}
+	var response httptest.ResponseRecorder
+	p.ServeHTTP(&response, request)
+	return &response
+}
+
+// HandleRequest processes a report payload as if it were uploaded as required
+// by the Reporting spec.  We assume that the payload is valid; if the pipeline
+// doesn't return a 204 ("success with no response content"), we return an
+// error.
+func (p *TestPipeline) HandleRequest(t *testing.T, payload []byte) error {
+	response := p.HandleCustomRequest(t, "POST", "application/report", payload)
+	if response.Code != http.StatusNoContent {
+		return fmt.Errorf("Incorrect status code: got %d, wanted %d", response.Code, http.StatusNoContent)
+	}
+	return nil
+}

--- a/pkg/pipelinetest/pipelinetest.go
+++ b/pkg/pipelinetest/pipelinetest.go
@@ -79,3 +79,16 @@ func (p *TestPipeline) HandleRequest(t *testing.T, payload []byte) error {
 	}
 	return nil
 }
+
+// StashReports is a pipeline processor that saves a copy of the report batch
+// into some other variable under your control.  You can use this to verify the
+// contents of the batch after the pipeline is done.
+type StashReports struct {
+	Dest *collector.ReportBatch
+}
+
+// ProcessReports saves a copy of the report batch into some other variable
+// under your control.
+func (s StashReports) ProcessReports(batch *collector.ReportBatch) {
+	*s.Dest = *batch
+}


### PR DESCRIPTION
The TestPipeline class would be useful for people writing test cases for their own custom report processor implementations.  This patch moves it into a helper package and makes a clearer separation between the parts that are general and the parts that depend on these particular test cases.

As a side effect, this patch also moves the test cases into a separate package.  This means that we can't depend on any package-internal details in our test cases, but that's probably a good thing.