### PR TITLE
Allow custom upload URLs in test cases

### DIFF
--- a/pkg/collector/pipeline_test.go
+++ b/pkg/collector/pipeline_test.go
@@ -65,7 +65,7 @@ func allPipelineTests() []testCase {
 
 func TestIgnoreNonPOST(t *testing.T) {
 	pipeline := newTestCase("valid-nel-report", "")
-	response := pipeline.HandleCustomRequest(t, "GET", "application/report", testdata(t, pipeline.testdataName(".json")))
+	response := pipeline.HandleCustomRequest(t, "GET", "https://example.com/upload/", "application/report", testdata(t, pipeline.testdataName(".json")))
 	if response.Code != http.StatusMethodNotAllowed {
 		t.Errorf("ServeHTTP(%s): got %d, wanted %d", pipeline.fullname(), response.Code, http.StatusMethodNotAllowed)
 		return
@@ -74,7 +74,7 @@ func TestIgnoreNonPOST(t *testing.T) {
 
 func TestIgnoreWrongContentType(t *testing.T) {
 	pipeline := newTestCase("valid-nel-report", "")
-	response := pipeline.HandleCustomRequest(t, "POST", "application/json", testdata(t, pipeline.testdataName(".json")))
+	response := pipeline.HandleCustomRequest(t, "POST", "https://example.com/upload/", "application/json", testdata(t, pipeline.testdataName(".json")))
 	if response.Code != http.StatusBadRequest {
 		t.Errorf("ServeHTTP(%s): got %d, wanted %d", pipeline.fullname(), response.Code, http.StatusBadRequest)
 		return

--- a/pkg/pipelinetest/pipelinetest.go
+++ b/pkg/pipelinetest/pipelinetest.go
@@ -57,8 +57,8 @@ func NewTestPipeline(remoteAddr string) *TestPipeline {
 // the given HTTP method and MIME type.  This is useful for test cases where you
 // want to verify that uploads that don't conform to the Reporting spec are
 // handled properly.
-func (p *TestPipeline) HandleCustomRequest(t *testing.T, method, mimeType string, payload []byte) *httptest.ResponseRecorder {
-	request := httptest.NewRequest(method, "https://example.com/upload/", bytes.NewReader(payload))
+func (p *TestPipeline) HandleCustomRequest(t *testing.T, method, uploadURL, mimeType string, payload []byte) *httptest.ResponseRecorder {
+	request := httptest.NewRequest(method, uploadURL, bytes.NewReader(payload))
 	request.Header.Add("Content-Type", mimeType)
 	if p.remoteAddr != "" {
 		request.RemoteAddr = p.remoteAddr
@@ -73,7 +73,7 @@ func (p *TestPipeline) HandleCustomRequest(t *testing.T, method, mimeType string
 // doesn't return a 204 ("success with no response content"), we return an
 // error.
 func (p *TestPipeline) HandleRequest(t *testing.T, payload []byte) error {
-	response := p.HandleCustomRequest(t, "POST", "application/report", payload)
+	response := p.HandleCustomRequest(t, "POST", "https://example.com/upload/", "application/report", payload)
 	if response.Code != http.StatusNoContent {
 		return fmt.Errorf("Incorrect status code: got %d, wanted %d", response.Code, http.StatusNoContent)
 	}


### PR DESCRIPTION
If you need to write custom report processors that depend on the contents of the upload URL, then you also need to able to specify the upload URLs in your test cases!