### PR TITLE
Allow multiple named annotations

### DIFF
--- a/pkg/collector/annotation.go
+++ b/pkg/collector/annotation.go
@@ -1,0 +1,51 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package collector
+
+// Annotations lets you attach an arbitrary collection of extra data to each
+// individual report, and to each report batch.  Each annotation has a name and
+// an arbitrary type; it's up to you to make sure that your processors don't
+// make conflicting assumptions about the type of an annotation with a
+// particular name.
+type Annotations struct {
+	Annotations map[string]interface{}
+}
+
+// GetAnnotation returns the annotation with the given name, or nil if there
+// isn't one.
+func (a *Annotations) GetAnnotation(name string) interface{} {
+	return a.Annotations[name]
+}
+
+// GetOrAddAnnotation returns the annotation with the given name, if it exists.
+// If it doesn't, then we save `defaultValue` as the new value for this
+// annotation, and return it.
+func (a *Annotations) GetOrAddAnnotation(name string, defaultValue interface{}) interface{} {
+	result, present := a.Annotations[name]
+	if present {
+		return result
+	}
+	a.SetAnnotation(name, defaultValue)
+	return defaultValue
+}
+
+// SetAnnotation adds an annotation, overwriting any existing annotation with
+// the same name.
+func (a *Annotations) SetAnnotation(name string, value interface{}) {
+	if a.Annotations == nil {
+		a.Annotations = make(map[string]interface{})
+	}
+	a.Annotations[name] = value
+}

--- a/pkg/collector/annotation_test.go
+++ b/pkg/collector/annotation_test.go
@@ -1,0 +1,50 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package collector_test
+
+import (
+	"testing"
+
+	"github.com/google/nel-collector/pkg/collector"
+)
+
+func TestAnnotations(t *testing.T) {
+	annotations := &collector.Annotations{}
+
+	// An annotation should start off not being present.
+	value := annotations.GetAnnotation("test")
+	if value != nil {
+		t.Errorf("GetAnnotation(%#v) = %#v, wanted nil", "test", value)
+	}
+
+	// But we can add it.
+	value = annotations.GetOrAddAnnotation("test", "hello world")
+	if value != "hello world" {
+		t.Errorf("GetOrAddAnnotation(%#v, %#v) = %#v, wanted %#v", "test", "hello world", value, "hello world")
+	}
+
+	// And we can get it again.
+	value = annotations.GetAnnotation("test")
+	if value != "hello world" {
+		t.Errorf("GetAnnotation(%#v) = %#v, wanted %#v", "test", value, "hello world")
+	}
+
+	// And we can overwrite it.
+	annotations.SetAnnotation("test", "goodbye world")
+	value = annotations.GetAnnotation("test")
+	if value != "goodbye world" {
+		t.Errorf("GetAnnotation(%#v) = %#v, wanted %#v", "test", value, "goodbye world")
+	}
+}

--- a/pkg/collector/pipeline.go
+++ b/pkg/collector/pipeline.go
@@ -48,7 +48,7 @@ type ReportBatch struct {
 
 	// An arbitrary set of extra data that you can attach to this batch of
 	// reports.
-	Annotation interface{}
+	Annotations
 }
 
 // A ReportProcessor implements one discrete processing step for handling

--- a/pkg/collector/pipeline_test.go
+++ b/pkg/collector/pipeline_test.go
@@ -145,9 +145,9 @@ var serverZones = map[string]string{
 type geoAnnotator struct{}
 
 func (g geoAnnotator) ProcessReports(batch *collector.ReportBatch) {
-	batch.Annotation = clientCountries[batch.ClientIP]
+	batch.SetAnnotation("ClientCountry", clientCountries[batch.ClientIP])
 	for i := range batch.Reports {
-		batch.Reports[i].Annotation = serverZones[batch.Reports[i].ServerIP]
+		batch.Reports[i].SetAnnotation("ServerZone", serverZones[batch.Reports[i].ServerIP])
 	}
 }
 

--- a/pkg/collector/report.go
+++ b/pkg/collector/report.go
@@ -59,7 +59,7 @@ type NelReport struct {
 	RawBody []byte
 
 	// An arbitrary set of extra data that you can attach to your reports.
-	Annotation interface{}
+	Annotations
 }
 
 type rawReport struct {

--- a/pkg/collector/testdata/multiple-valid-nel-reports.ipv4.annotated.json
+++ b/pkg/collector/testdata/multiple-valid-nel-reports.ipv4.annotated.json
@@ -13,7 +13,9 @@
   },
   "ClientIP": "192.0.2.1",
   "ClientUserAgent": "",
-  "Annotation": "US",
+  "Annotations": {
+    "ClientCountry": "US"
+  },
   "Reports": [
     {
       "Age": 500,
@@ -27,7 +29,9 @@
       "ElapsedTime": 45,
       "Type": "ok",
       "RawBody": null,
-      "Annotation": "us-east1-a"
+      "Annotations": {
+        "ServerZone": "us-east1-a"
+      }
     },
     {
       "Age": 500,
@@ -41,7 +45,9 @@
       "ElapsedTime": 45,
       "Type": "ok",
       "RawBody": null,
-      "Annotation": "us-west1-b"
+      "Annotations": {
+        "ServerZone": "us-west1-b"
+      }
     }
   ]
 }

--- a/pkg/collector/testdata/multiple-valid-nel-reports.ipv4.keep-nel.json
+++ b/pkg/collector/testdata/multiple-valid-nel-reports.ipv4.keep-nel.json
@@ -13,7 +13,7 @@
   },
   "ClientIP": "192.0.2.1",
   "ClientUserAgent": "",
-  "Annotation": null,
+  "Annotations": null,
   "Reports": [
     {
       "Age": 500,
@@ -27,7 +27,7 @@
       "ElapsedTime": 45,
       "Type": "ok",
       "RawBody": null,
-      "Annotation": null
+      "Annotations": null
     },
     {
       "Age": 500,
@@ -41,7 +41,7 @@
       "ElapsedTime": 45,
       "Type": "ok",
       "RawBody": null,
-      "Annotation": null
+      "Annotations": null
     }
   ]
 }

--- a/pkg/collector/testdata/multiple-valid-nel-reports.ipv4.processed.json
+++ b/pkg/collector/testdata/multiple-valid-nel-reports.ipv4.processed.json
@@ -13,7 +13,7 @@
   },
   "ClientIP": "192.0.2.1",
   "ClientUserAgent": "",
-  "Annotation": null,
+  "Annotations": null,
   "Reports": [
     {
       "Age": 500,
@@ -27,7 +27,7 @@
       "ElapsedTime": 45,
       "Type": "ok",
       "RawBody": null,
-      "Annotation": null
+      "Annotations": null
     },
     {
       "Age": 500,
@@ -41,7 +41,7 @@
       "ElapsedTime": 45,
       "Type": "ok",
       "RawBody": null,
-      "Annotation": null
+      "Annotations": null
     }
   ]
 }

--- a/pkg/collector/testdata/multiple-valid-nel-reports.ipv6.annotated.json
+++ b/pkg/collector/testdata/multiple-valid-nel-reports.ipv6.annotated.json
@@ -13,7 +13,9 @@
   },
   "ClientIP": "2001:db8::2",
   "ClientUserAgent": "",
-  "Annotation": "",
+  "Annotations": {
+    "ClientCountry": ""
+  },
   "Reports": [
     {
       "Age": 500,
@@ -27,7 +29,9 @@
       "ElapsedTime": 45,
       "Type": "ok",
       "RawBody": null,
-      "Annotation": "us-east1-a"
+      "Annotations": {
+        "ServerZone": "us-east1-a"
+      }
     },
     {
       "Age": 500,
@@ -41,7 +45,9 @@
       "ElapsedTime": 45,
       "Type": "ok",
       "RawBody": null,
-      "Annotation": "us-west1-b"
+      "Annotations": {
+        "ServerZone": "us-west1-b"
+      }
     }
   ]
 }

--- a/pkg/collector/testdata/multiple-valid-nel-reports.ipv6.keep-nel.json
+++ b/pkg/collector/testdata/multiple-valid-nel-reports.ipv6.keep-nel.json
@@ -13,7 +13,7 @@
   },
   "ClientIP": "2001:db8::2",
   "ClientUserAgent": "",
-  "Annotation": null,
+  "Annotations": null,
   "Reports": [
     {
       "Age": 500,
@@ -27,7 +27,7 @@
       "ElapsedTime": 45,
       "Type": "ok",
       "RawBody": null,
-      "Annotation": null
+      "Annotations": null
     },
     {
       "Age": 500,
@@ -41,7 +41,7 @@
       "ElapsedTime": 45,
       "Type": "ok",
       "RawBody": null,
-      "Annotation": null
+      "Annotations": null
     }
   ]
 }

--- a/pkg/collector/testdata/multiple-valid-nel-reports.ipv6.processed.json
+++ b/pkg/collector/testdata/multiple-valid-nel-reports.ipv6.processed.json
@@ -13,7 +13,7 @@
   },
   "ClientIP": "2001:db8::2",
   "ClientUserAgent": "",
-  "Annotation": null,
+  "Annotations": null,
   "Reports": [
     {
       "Age": 500,
@@ -27,7 +27,7 @@
       "ElapsedTime": 45,
       "Type": "ok",
       "RawBody": null,
-      "Annotation": null
+      "Annotations": null
     },
     {
       "Age": 500,
@@ -41,7 +41,7 @@
       "ElapsedTime": 45,
       "Type": "ok",
       "RawBody": null,
-      "Annotation": null
+      "Annotations": null
     }
   ]
 }

--- a/pkg/collector/testdata/multiple-valid-nel-reports.parsed.json
+++ b/pkg/collector/testdata/multiple-valid-nel-reports.parsed.json
@@ -11,7 +11,7 @@
     "ElapsedTime": 45,
     "Type": "ok",
     "RawBody": null,
-    "Annotation": null
+    "Annotations": null
   },
   {
     "Age": 500,
@@ -25,6 +25,6 @@
     "ElapsedTime": 45,
     "Type": "ok",
     "RawBody": null,
-    "Annotation": null
+    "Annotations": null
   }
 ]

--- a/pkg/collector/testdata/non-nel-report.ipv4.annotated.json
+++ b/pkg/collector/testdata/non-nel-report.ipv4.annotated.json
@@ -13,7 +13,9 @@
   },
   "ClientIP": "192.0.2.1",
   "ClientUserAgent": "",
-  "Annotation": "US",
+  "Annotations": {
+    "ClientCountry": "US"
+  },
   "Reports": [
     {
       "Age": 500,
@@ -27,7 +29,9 @@
       "ElapsedTime": 0,
       "Type": "",
       "RawBody": "eyJyYW5kb20iOiAic3R1ZmYiLCAiaWdub3JlIjogMTAwfQ==",
-      "Annotation": ""
+      "Annotations": {
+        "ServerZone": ""
+      }
     }
   ]
 }

--- a/pkg/collector/testdata/non-nel-report.ipv4.keep-nel.json
+++ b/pkg/collector/testdata/non-nel-report.ipv4.keep-nel.json
@@ -13,6 +13,6 @@
   },
   "ClientIP": "192.0.2.1",
   "ClientUserAgent": "",
-  "Annotation": null,
+  "Annotations": null,
   "Reports": []
 }

--- a/pkg/collector/testdata/non-nel-report.ipv4.processed.json
+++ b/pkg/collector/testdata/non-nel-report.ipv4.processed.json
@@ -13,7 +13,7 @@
   },
   "ClientIP": "192.0.2.1",
   "ClientUserAgent": "",
-  "Annotation": null,
+  "Annotations": null,
   "Reports": [
     {
       "Age": 500,
@@ -27,7 +27,7 @@
       "ElapsedTime": 0,
       "Type": "",
       "RawBody": "eyJyYW5kb20iOiAic3R1ZmYiLCAiaWdub3JlIjogMTAwfQ==",
-      "Annotation": null
+      "Annotations": null
     }
   ]
 }

--- a/pkg/collector/testdata/non-nel-report.ipv6.annotated.json
+++ b/pkg/collector/testdata/non-nel-report.ipv6.annotated.json
@@ -13,7 +13,9 @@
   },
   "ClientIP": "2001:db8::2",
   "ClientUserAgent": "",
-  "Annotation": "",
+  "Annotations": {
+    "ClientCountry": ""
+  },
   "Reports": [
     {
       "Age": 500,
@@ -27,7 +29,9 @@
       "ElapsedTime": 0,
       "Type": "",
       "RawBody": "eyJyYW5kb20iOiAic3R1ZmYiLCAiaWdub3JlIjogMTAwfQ==",
-      "Annotation": ""
+      "Annotations": {
+        "ServerZone": ""
+      }
     }
   ]
 }

--- a/pkg/collector/testdata/non-nel-report.ipv6.keep-nel.json
+++ b/pkg/collector/testdata/non-nel-report.ipv6.keep-nel.json
@@ -13,6 +13,6 @@
   },
   "ClientIP": "2001:db8::2",
   "ClientUserAgent": "",
-  "Annotation": null,
+  "Annotations": null,
   "Reports": []
 }

--- a/pkg/collector/testdata/non-nel-report.ipv6.processed.json
+++ b/pkg/collector/testdata/non-nel-report.ipv6.processed.json
@@ -13,7 +13,7 @@
   },
   "ClientIP": "2001:db8::2",
   "ClientUserAgent": "",
-  "Annotation": null,
+  "Annotations": null,
   "Reports": [
     {
       "Age": 500,
@@ -27,7 +27,7 @@
       "ElapsedTime": 0,
       "Type": "",
       "RawBody": "eyJyYW5kb20iOiAic3R1ZmYiLCAiaWdub3JlIjogMTAwfQ==",
-      "Annotation": null
+      "Annotations": null
     }
   ]
 }

--- a/pkg/collector/testdata/non-nel-report.parsed.json
+++ b/pkg/collector/testdata/non-nel-report.parsed.json
@@ -11,6 +11,6 @@
     "ElapsedTime": 0,
     "Type": "",
     "RawBody": "eyJyYW5kb20iOiAic3R1ZmYiLCAiaWdub3JlIjogMTAwfQ==",
-    "Annotation": null
+    "Annotations": null
   }
 ]

--- a/pkg/collector/testdata/valid-nel-report.ipv4.annotated.json
+++ b/pkg/collector/testdata/valid-nel-report.ipv4.annotated.json
@@ -13,7 +13,9 @@
   },
   "ClientIP": "192.0.2.1",
   "ClientUserAgent": "",
-  "Annotation": "US",
+  "Annotations": {
+    "ClientCountry": "US"
+  },
   "Reports": [
     {
       "Age": 500,
@@ -27,7 +29,9 @@
       "ElapsedTime": 45,
       "Type": "ok",
       "RawBody": null,
-      "Annotation": "us-east1-a"
+      "Annotations": {
+        "ServerZone": "us-east1-a"
+      }
     }
   ]
 }

--- a/pkg/collector/testdata/valid-nel-report.ipv4.keep-nel.json
+++ b/pkg/collector/testdata/valid-nel-report.ipv4.keep-nel.json
@@ -13,7 +13,7 @@
   },
   "ClientIP": "192.0.2.1",
   "ClientUserAgent": "",
-  "Annotation": null,
+  "Annotations": null,
   "Reports": [
     {
       "Age": 500,
@@ -27,7 +27,7 @@
       "ElapsedTime": 45,
       "Type": "ok",
       "RawBody": null,
-      "Annotation": null
+      "Annotations": null
     }
   ]
 }

--- a/pkg/collector/testdata/valid-nel-report.ipv4.processed.json
+++ b/pkg/collector/testdata/valid-nel-report.ipv4.processed.json
@@ -13,7 +13,7 @@
   },
   "ClientIP": "192.0.2.1",
   "ClientUserAgent": "",
-  "Annotation": null,
+  "Annotations": null,
   "Reports": [
     {
       "Age": 500,
@@ -27,7 +27,7 @@
       "ElapsedTime": 45,
       "Type": "ok",
       "RawBody": null,
-      "Annotation": null
+      "Annotations": null
     }
   ]
 }

--- a/pkg/collector/testdata/valid-nel-report.ipv6.annotated.json
+++ b/pkg/collector/testdata/valid-nel-report.ipv6.annotated.json
@@ -13,7 +13,9 @@
   },
   "ClientIP": "2001:db8::2",
   "ClientUserAgent": "",
-  "Annotation": "",
+  "Annotations": {
+    "ClientCountry": ""
+  },
   "Reports": [
     {
       "Age": 500,
@@ -27,7 +29,9 @@
       "ElapsedTime": 45,
       "Type": "ok",
       "RawBody": null,
-      "Annotation": "us-east1-a"
+      "Annotations": {
+        "ServerZone": "us-east1-a"
+      }
     }
   ]
 }

--- a/pkg/collector/testdata/valid-nel-report.ipv6.keep-nel.json
+++ b/pkg/collector/testdata/valid-nel-report.ipv6.keep-nel.json
@@ -13,7 +13,7 @@
   },
   "ClientIP": "2001:db8::2",
   "ClientUserAgent": "",
-  "Annotation": null,
+  "Annotations": null,
   "Reports": [
     {
       "Age": 500,
@@ -27,7 +27,7 @@
       "ElapsedTime": 45,
       "Type": "ok",
       "RawBody": null,
-      "Annotation": null
+      "Annotations": null
     }
   ]
 }

--- a/pkg/collector/testdata/valid-nel-report.ipv6.processed.json
+++ b/pkg/collector/testdata/valid-nel-report.ipv6.processed.json
@@ -13,7 +13,7 @@
   },
   "ClientIP": "2001:db8::2",
   "ClientUserAgent": "",
-  "Annotation": null,
+  "Annotations": null,
   "Reports": [
     {
       "Age": 500,
@@ -27,7 +27,7 @@
       "ElapsedTime": 45,
       "Type": "ok",
       "RawBody": null,
-      "Annotation": null
+      "Annotations": null
     }
   ]
 }

--- a/pkg/collector/testdata/valid-nel-report.parsed.json
+++ b/pkg/collector/testdata/valid-nel-report.parsed.json
@@ -11,6 +11,6 @@
     "ElapsedTime": 45,
     "Type": "ok",
     "RawBody": null,
-    "Annotation": null
+    "Annotations": null
   }
 ]


### PR DESCRIPTION
Instead of having a single `Annotation` field on reports and batches, there's now a separate map-like class that we embed in each of them, which lets you define several independent named annotations.  This will make is easier to different "groups" of processors that operate on different annotations, without having them conflict with each other.