### PR TITLE
Add io.Writer for building annotations

### DIFF
--- a/pkg/collector/annotation.go
+++ b/pkg/collector/annotation.go
@@ -69,8 +69,9 @@ type annotationWriter struct {
 
 // Write appends the contents of p to the current value of the annotation.
 func (w *annotationWriter) Write(p []byte) (int, error) {
-	// If there's already a value for the annotation, ensure that it's a []byte.
-	// If not, start with a nil slice.
+	// If there's already a value for the annotation, ensure that it's a []byte,
+	// raising an error if it's some other type.  If there is no value, start with
+	// a nil slice.
 	var b []byte
 	value := w.a.GetAnnotation(w.name)
 	if value != nil {

--- a/pkg/collector/annotation_test.go
+++ b/pkg/collector/annotation_test.go
@@ -48,3 +48,22 @@ func TestAnnotations(t *testing.T) {
 		t.Errorf("GetAnnotation(%#v) = %#v, wanted %#v", "test", value, "goodbye world")
 	}
 }
+
+func TestAnnotationWriter(t *testing.T) {
+	annotations := &collector.Annotations{}
+	writer := annotations.AnnotationWriter("test")
+
+	// An annotation should start off not being present.
+	value := annotations.GetAnnotation("test")
+	if value != nil {
+		t.Errorf("GetAnnotation(%#v) = %#v, wanted nil", "test", value)
+	}
+
+	// But we can write to it.
+	writer.Write([]byte("hello"))
+	writer.Write([]byte(" world"))
+	value = string(annotations.GetAnnotation("test").([]byte))
+	if value != "hello world" {
+		t.Errorf("GetAnnotation(%#v) = %#v, wanted %#v", "test", value, "hello world")
+	}
+}


### PR DESCRIPTION
You can use SetAnnotation if you have a single value that you want to use for an annotation.  This patch adds an io.Writer implementation that lets you build up the content of the annotation as you go.