### PR TITLE
Move ReportBatch

### DIFF
--- a/pkg/collector/report.go
+++ b/pkg/collector/report.go
@@ -16,6 +16,11 @@ package collector
 
 import (
 	"encoding/json"
+	"fmt"
+	"io"
+	"net/url"
+	"strconv"
+	"time"
 )
 
 // A NelReport describes a single network error report.
@@ -143,4 +148,49 @@ func (r NelReport) MarshalJSON() ([]byte, error) {
 		URL:        r.URL,
 		Body:       body,
 	})
+}
+
+// ReportBatch is a collection of reports that should all be processed together.
+// We will create a new batch for each upload that the collector receives.
+// Certain processors might join batches together or split them up.
+type ReportBatch struct {
+	Reports []NelReport
+
+	// When this batch was received by the collector
+	Time time.Time
+
+	// The URL that was used to upload the report.
+	CollectorURL url.URL
+
+	// The IP address of the client that uploaded the batch of reports.  You can
+	// typically assume that's the same IP address that was used for the original
+	// requests.  The IP address will be encoded as a string; for example,
+	// "192.0.2.1" or "2001:db8::2".
+	ClientIP string
+
+	// The user agent of the client that uploaded the batch of reports.
+	ClientUserAgent string
+
+	// An arbitrary set of extra data that you can attach to this batch of
+	// reports.
+	Annotations
+}
+
+// PrintBatchAsCLF prints out a summary of each report in the batch using a
+// format not unlike the format of an Apache access.log file.
+func PrintBatchAsCLF(batch *ReportBatch, w io.Writer) {
+	time := batch.Time.UTC().Format("02/Jan/2006:15:04:05.000 -0700")
+	for _, report := range batch.Reports {
+		if report.ReportType == "network-error" {
+			var result string
+			if report.Type == "ok" || report.Type == "http.error" {
+				result = strconv.Itoa(report.StatusCode)
+			} else {
+				result = report.Type
+			}
+			fmt.Fprintf(w, "%s - - [%s] \"GET %s\" %s -\n", batch.ClientIP, time, report.URL, result)
+		} else {
+			fmt.Fprintf(w, "%s - - [%s] \"GET %s\" <%s> -\n", batch.ClientIP, time, report.URL, report.ReportType)
+		}
+	}
 }


### PR DESCRIPTION
No changes to the type, but now all of the "data" types are in report.go.