### PR TITLE
Remove StashReports processor

### DIFF
--- a/pkg/collector/filter_test.go
+++ b/pkg/collector/filter_test.go
@@ -19,16 +19,13 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/nel-collector/pkg/collector"
-	"github.com/google/nel-collector/pkg/pipelinetest"
 )
 
 func TestKeepNelReports(t *testing.T) {
 	for _, p := range allPipelineTests() {
 		t.Run("KeepNelReports:"+p.fullname(), func(t *testing.T) {
-			var batch collector.ReportBatch
 			p.AddProcessor(&collector.KeepNelReports{})
-			p.AddProcessor(&pipelinetest.StashReports{&batch})
-			err := p.HandleRequest(t, testdata(t, p.testdataName(".json")))
+			batch, err := p.HandleRequest(t, testdata(t, p.testdataName(".json")))
 			if err != nil {
 				t.Errorf("HandleRequest(%s): %v", p.fullname(), err)
 				return

--- a/pkg/collector/utils_test.go
+++ b/pkg/collector/utils_test.go
@@ -108,10 +108,10 @@ func decodeRawReports(b []byte, reports *[]collector.NelReport) error {
 
 // encodeRawBatch marshals a batch of NelReports, including any custom
 // annotations, without using our custom spec-aware JSON parsing rules.
-func encodeRawBatch(batch collector.ReportBatch) ([]byte, error) {
+func encodeRawBatch(batch *collector.ReportBatch) ([]byte, error) {
 	var err error
 	var rawBatch struct {
-		collector.ReportBatch
+		*collector.ReportBatch
 		RawReports json.RawMessage `json:"Reports"`
 	}
 


### PR DESCRIPTION
Instead we provide a ServeHTTP-like method that returns the final batch directly.