### PR TITLE
Move raw encoding into public API

### DIFF
--- a/pkg/collector/filter_test.go
+++ b/pkg/collector/filter_test.go
@@ -34,9 +34,9 @@ func TestKeepNelReports(t *testing.T) {
 				return
 			}
 
-			got, err := encodeRawBatch(batch)
+			got, err := collector.EncodeRawBatch(batch)
 			if err != nil {
-				t.Errorf("encodeRawBatch(%s): %v", p.fullname(), err)
+				t.Errorf("EncodeRawBatch(%s): %v", p.fullname(), err)
 				return
 			}
 

--- a/pkg/collector/pipeline_test.go
+++ b/pkg/collector/pipeline_test.go
@@ -92,9 +92,9 @@ func TestProcessReports(t *testing.T) {
 				return
 			}
 
-			got, err := encodeRawBatch(batch)
+			got, err := collector.EncodeRawBatch(batch)
 			if err != nil {
-				t.Errorf("encodeRawBatch(%s): %v", p.fullname(), err)
+				t.Errorf("EncodeRawBatch(%s): %v", p.fullname(), err)
 				return
 			}
 
@@ -163,9 +163,9 @@ func TestCustomAnnotation(t *testing.T) {
 				return
 			}
 
-			got, err := encodeRawBatch(batch)
+			got, err := collector.EncodeRawBatch(batch)
 			if err != nil {
-				t.Errorf("encodeRawBatch(%s): %v", p.fullname(), err)
+				t.Errorf("EncodeRawBatch(%s): %v", p.fullname(), err)
 				return
 			}
 

--- a/pkg/collector/report.go
+++ b/pkg/collector/report.go
@@ -144,3 +144,56 @@ func (r NelReport) MarshalJSON() ([]byte, error) {
 		Body:       body,
 	})
 }
+
+// EncodeRawReports marshals an array of NelReports without using our custom
+// spec-aware JSON parsing rules, instead dumping out the content exactly as it
+// looks in Go.  This is used extensively in test cases to compare the results
+// of parsing and annotating against golden files.
+func EncodeRawReports(reports []NelReport) ([]byte, error) {
+	// This type alias lets us override our spec-aware JSON parsing rules, and
+	// dump out the content of a NelReport instance exactly as it looks in Go.
+	type ParsedNelReport NelReport
+	parsedReports := make([]ParsedNelReport, len(reports))
+	for i := range reports {
+		parsedReports[i] = (ParsedNelReport)(reports[i])
+	}
+	return json.MarshalIndent(parsedReports, "", "  ")
+}
+
+// DecodeRawReports unmarshals an array of NelReports without using our custom
+// spec-aware JSON parsing rules.  It's the inverse of EncodeRawReports.
+func DecodeRawReports(b []byte, reports *[]NelReport) error {
+	// This type alias lets us override our spec-aware JSON parsing rules, and
+	// dump out the content of a NelReport instance exactly as it looks in Go.
+	type ParsedNelReport NelReport
+	var parsedReports []ParsedNelReport
+	err := json.Unmarshal(b, &parsedReports)
+	if err != nil {
+		return err
+	}
+
+	*reports = make([]NelReport, len(parsedReports))
+	for i := range parsedReports {
+		(*reports)[i] = (NelReport)(parsedReports[i])
+	}
+	return nil
+}
+
+// EncodeRawBatch marshals a batch of NelReports, including any custom
+// annotations, without using our custom spec-aware JSON parsing rules.
+func EncodeRawBatch(batch ReportBatch) ([]byte, error) {
+	var err error
+	var rawBatch struct {
+		ReportBatch
+		RawReports json.RawMessage `json:"Reports"`
+	}
+
+	rawBatch.ReportBatch = batch
+	rawBatch.RawReports, err = EncodeRawReports(rawBatch.Reports)
+	if err != nil {
+		return nil, err
+	}
+
+	rawBatch.Reports = nil
+	return json.MarshalIndent(rawBatch, "", "  ")
+}

--- a/pkg/collector/report_test.go
+++ b/pkg/collector/report_test.go
@@ -42,9 +42,9 @@ func TestNelReport(t *testing.T) {
 				return
 			}
 
-			got, err := encodeRawReports(reports)
+			got, err := collector.EncodeRawReports(reports)
 			if err != nil {
-				t.Errorf("encodeRawReports(%s): %v", name, err)
+				t.Errorf("EncodeRawReports(%s): %v", name, err)
 				return
 			}
 
@@ -63,9 +63,9 @@ func TestNelReport(t *testing.T) {
 			parsedData := testdata(t, parsedFile)
 
 			var reports []collector.NelReport
-			err := decodeRawReports(parsedData, &reports)
+			err := collector.DecodeRawReports(parsedData, &reports)
 			if err != nil {
-				t.Errorf("decodeRawReports(%s): %v", name, err)
+				t.Errorf("DecodeRawReports(%s): %v", name, err)
 				return
 			}
 

--- a/pkg/collector/utils_test.go
+++ b/pkg/collector/utils_test.go
@@ -21,8 +21,6 @@ import (
 	"io/ioutil"
 	"path/filepath"
 	"testing"
-
-	"github.com/google/nel-collector/pkg/collector"
 )
 
 var update = flag.Bool("update", false, "update .golden files")
@@ -70,57 +68,4 @@ func compactJSON(b []byte) []byte {
 		return nil
 	}
 	return bytes.Bytes()
-}
-
-// encodeRawReports marshals an array of NelReports without using our custom
-// spec-aware JSON parsing rules, instead dumping out the content exactly as it
-// looks in Go.  This is used extensively in test cases to compare the results
-// of parsing and annotating against golden files.
-func encodeRawReports(reports []collector.NelReport) ([]byte, error) {
-	// This type alias lets us override our spec-aware JSON parsing rules, and
-	// dump out the content of a NelReport instance exactly as it looks in Go.
-	type ParsedNelReport collector.NelReport
-	parsedReports := make([]ParsedNelReport, len(reports))
-	for i := range reports {
-		parsedReports[i] = (ParsedNelReport)(reports[i])
-	}
-	return json.MarshalIndent(parsedReports, "", "  ")
-}
-
-// decodeRawReports unmarshals an array of NelReports without using our custom
-// spec-aware JSON parsing rules.  It's the inverse of encodeRawReports.
-func decodeRawReports(b []byte, reports *[]collector.NelReport) error {
-	// This type alias lets us override our spec-aware JSON parsing rules, and
-	// dump out the content of a NelReport instance exactly as it looks in Go.
-	type ParsedNelReport collector.NelReport
-	var parsedReports []ParsedNelReport
-	err := json.Unmarshal(b, &parsedReports)
-	if err != nil {
-		return err
-	}
-
-	*reports = make([]collector.NelReport, len(parsedReports))
-	for i := range parsedReports {
-		(*reports)[i] = (collector.NelReport)(parsedReports[i])
-	}
-	return nil
-}
-
-// encodeRawBatch marshals a batch of NelReports, including any custom
-// annotations, without using our custom spec-aware JSON parsing rules.
-func encodeRawBatch(batch collector.ReportBatch) ([]byte, error) {
-	var err error
-	var rawBatch struct {
-		collector.ReportBatch
-		RawReports json.RawMessage `json:"Reports"`
-	}
-
-	rawBatch.ReportBatch = batch
-	rawBatch.RawReports, err = encodeRawReports(rawBatch.Reports)
-	if err != nil {
-		return nil, err
-	}
-
-	rawBatch.Reports = nil
-	return json.MarshalIndent(rawBatch, "", "  ")
 }


### PR DESCRIPTION
These functions encode the "raw" structure of a report or batch of reports, exactly as they'd appear in Go, without using our special logic that knows about the payload format mandated by the Reporting and NEL specs.  This functionality is more generally useful, so let's expose it in the public API.