### PR TITLE
 Respond to CORS with 200 Header, don't try to process reports

### DIFF
--- a/pkg/collector/pipeline.go
+++ b/pkg/collector/pipeline.go
@@ -125,6 +125,7 @@ func serveCORS(w http.ResponseWriter, r *http.Request) {
 func (p *Pipeline) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if r.Method == "OPTIONS" {
 		serveCORS(w, r)
+		return
 	}
 	p.ProcessReports(w, r)
 }

--- a/pkg/collector/pipeline_test.go
+++ b/pkg/collector/pipeline_test.go
@@ -43,6 +43,9 @@ func TestRespondsToOptionsRequest(t *testing.T) {
 	if want, got := "*", response.Header().Get("Access-Control-Allow-Origin"); got != want {
 		t.Errorf("response.Header().Get(\"Access-Control-Allow-Origin\"): got %v, want %v", got, want)
 	}
+	if want, got := 200, response.Result().StatusCode; got != want {
+		t.Errorf("response.Result().StatusCode: got %v, want %v", got, want)
+	}
 }
 
 func TestIgnoreNonPOSTNonOPTIONS(t *testing.T) {


### PR DESCRIPTION
Fix bug in which CORS requests would get a 4xx error. Added test to check for a status code of 200.