### PR TITLE
Add per-request context parameter for each pipeline stage.

### DIFF
--- a/pkg/collector/pipeline.go
+++ b/pkg/collector/pipeline.go
@@ -83,6 +83,7 @@ func (p *Pipeline) AddProcessor(processor ReportProcessor) {
 	p.processors = append(p.processors, processor)
 }
 
+// SetContextGetter overrides the default (or current) ContextGetter with cg.
 func (p *Pipeline) SetContextGetter(cg ContextGetter) {
 	p.ctxGetter = cg
 }

--- a/pkg/collector/pipeline.go
+++ b/pkg/collector/pipeline.go
@@ -52,12 +52,12 @@ type ContextGetter interface {
 	Context(r *http.Request) context.Context
 }
 
-// DefaultContextGetter implements a ContextGetter that gets the context
+// defaultContextGetter implements a ContextGetter that gets the context
 // contained directly within the request
-type DefaultContextGetter struct{}
+type defaultContextGetter struct{}
 
 // Context returns the context contained directly within the request.
-func (d DefaultContextGetter) Context(r *http.Request) context.Context {
+func (d defaultContextGetter) Context(r *http.Request) context.Context {
 	return r.Context()
 }
 

--- a/pkg/collector/pipeline.go
+++ b/pkg/collector/pipeline.go
@@ -75,7 +75,7 @@ type Pipeline struct {
 // production pipelines, just instantiate the Pipeline type yourself
 // (&Pipeline{}).
 func NewPipeline(clock Clock) *Pipeline {
-	return &Pipeline{ctxGetter: DefaultContextGetter{}, clock: clock}
+	return &Pipeline{ctxGetter: defaultContextGetter{}, clock: clock}
 }
 
 // AddProcessor adds a new processor to the pipeline.

--- a/pkg/collector/pipeline_test.go
+++ b/pkg/collector/pipeline_test.go
@@ -16,6 +16,7 @@ package collector_test
 
 import (
 	"bytes"
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
@@ -100,7 +101,7 @@ var serverZones = map[string]string{
 
 type geoAnnotator struct{}
 
-func (g geoAnnotator) ProcessReports(batch *collector.ReportBatch) {
+func (g geoAnnotator) ProcessReports(ctx context.Context, batch *collector.ReportBatch) {
 	batch.SetAnnotation("ClientCountry", clientCountries[batch.ClientIP])
 	for i := range batch.Reports {
 		batch.Reports[i].SetAnnotation("ServerZone", serverZones[batch.Reports[i].ServerIP])

--- a/pkg/core/dumper.go
+++ b/pkg/core/dumper.go
@@ -15,6 +15,7 @@
 package core
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"os"
@@ -32,7 +33,7 @@ type DumpReportsAsCLF struct {
 }
 
 // ProcessReports prints out a summary of each report in the batch.
-func (d DumpReportsAsCLF) ProcessReports(batch *collector.ReportBatch) {
+func (d DumpReportsAsCLF) ProcessReports(ctx context.Context, batch *collector.ReportBatch) {
 	writer := d.Writer
 	if writer == nil {
 		writer = batch.AnnotationWriter("TestResult")

--- a/pkg/core/filter.go
+++ b/pkg/core/filter.go
@@ -15,6 +15,8 @@
 package core
 
 import (
+	"context"
+
 	"github.com/BurntSushi/toml"
 	"github.com/google/nel-collector/pkg/collector"
 )
@@ -23,7 +25,7 @@ import (
 type KeepNelReports struct{}
 
 // ProcessReports throws away any non-NEL reports.
-func (KeepNelReports) ProcessReports(batch *collector.ReportBatch) {
+func (KeepNelReports) ProcessReports(ctx context.Context, batch *collector.ReportBatch) {
 	var filtered []collector.NelReport
 	for _, report := range batch.Reports {
 		if report.ReportType == "network-error" {

--- a/pkg/pipelinetest/pipelinetest.go
+++ b/pkg/pipelinetest/pipelinetest.go
@@ -18,6 +18,7 @@ package pipelinetest
 
 import (
 	"bytes"
+	"context"
 	"io/ioutil"
 	"log"
 	"net/http"
@@ -162,7 +163,7 @@ func (p *PipelineTest) Run(t *testing.T) {
 				}
 
 				var response httptest.ResponseRecorder
-				batch := p.Pipeline.ProcessReports(&response, request)
+				batch := p.Pipeline.ProcessReports(context.Background(), &response, request)
 				if response.Code != http.StatusNoContent {
 					t.Errorf("ProcessReports(%s:%s) got status code %d, wanted %d", payloadName, ip.tag, response.Code, http.StatusNoContent)
 					return
@@ -314,7 +315,7 @@ type EncodeBatchAsResult struct{}
 
 // ProcessReports saves a copy of the report batch into the TestResult
 // annotation.
-func (e EncodeBatchAsResult) ProcessReports(batch *collector.ReportBatch) {
+func (e EncodeBatchAsResult) ProcessReports(ctx context.Context, batch *collector.ReportBatch) {
 	encoded, _ := collector.EncodeRawBatch(batch)
 	batch.SetAnnotation("TestResult", encoded)
 }


### PR DESCRIPTION
A Context in go contains any relevant information that needs to be
passed around for requests. When handling an HTTP request, any functions
called from the handler should take a context parameter to preserve this
information. In general, the context is extracted directly from the
request, as implemented in DefaultContextGetter, but some use cases
require more advanced logic, and thus Pipeline recieves a ContextGetter
interface instead of just extracting the context directly.