### PR TITLE
Remove support for Go 1.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 go:
-  - "1.8"
   - "1.10"
+  - "1.11"
   - "1.x"
 
 install:


### PR DESCRIPTION
That version is no longer supported by the Go team, so we don't need to
run our test suite against it.