### PR TITLE
Use correct MIME type

### DIFF
--- a/pkg/collector/pipeline.go
+++ b/pkg/collector/pipeline.go
@@ -77,8 +77,8 @@ func (p *Pipeline) ProcessReports(ctx context.Context, w http.ResponseWriter, r 
 	}
 
 	contentType := r.Header.Get("Content-Type")
-	if contentType != "application/report" {
-		http.Error(w, "Must use application/report to upload reports", http.StatusBadRequest)
+	if contentType != "application/reports+json" {
+		http.Error(w, "Must use application/reports+json to upload reports", http.StatusBadRequest)
 		return nil
 	}
 

--- a/pkg/collector/pipeline_test.go
+++ b/pkg/collector/pipeline_test.go
@@ -52,7 +52,7 @@ func TestRespondsToOptionsRequest(t *testing.T) {
 func TestIgnoreNonPOSTNonOPTIONS(t *testing.T) {
 	pipeline := collector.NewPipeline(pipelinetest.NewSimulatedClock())
 	request := httptest.NewRequest("GET", "https://example.com/upload/", bytes.NewReader(testdata(validNelReportPath)))
-	request.Header.Add("Content-Type", "application/report")
+	request.Header.Add("Content-Type", "application/reports+json")
 	var response httptest.ResponseRecorder
 	pipeline.ServeHTTP(&response, request)
 	if want := http.StatusMethodNotAllowed; response.Code != want {

--- a/pkg/pipelinetest/pipelinetest.go
+++ b/pkg/pipelinetest/pipelinetest.go
@@ -157,7 +157,7 @@ func (p *PipelineTest) Run(t *testing.T) {
 				}
 
 				request := httptest.NewRequest("POST", "https://example.com/upload/", bytes.NewReader(payload))
-				request.Header.Add("Content-Type", "application/report")
+				request.Header.Add("Content-Type", "application/reports+json")
 				if ip.remoteAddr != "" {
 					request.RemoteAddr = ip.remoteAddr
 				}


### PR DESCRIPTION
The Reporting API requires `application/reports+json` as the MIME type for report uploads.  We were still using `application/report`, which is an old spelling.