### PR TITLE
Isolate logic for extracting ReportBatch from a http.Request.

### DIFF
--- a/pkg/collector/report.go
+++ b/pkg/collector/report.go
@@ -192,6 +192,8 @@ type ReportBatch struct {
 	Annotations
 }
 
+// NewReportBatch takes a HTTP request and a clock and fills in a ReportBatch,
+// returning an error if parsing fails.
 func NewReportBatch(r *http.Request, clock Clock) (*ReportBatch, error) {
 	host, _, err := net.SplitHostPort(r.RemoteAddr)
 	if err != nil {

--- a/pkg/collector/report.go
+++ b/pkg/collector/report.go
@@ -18,6 +18,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net"
+	"net/http"
 	"net/url"
 	"strconv"
 	"time"
@@ -188,6 +190,25 @@ type ReportBatch struct {
 	// An arbitrary set of extra data that you can attach to this batch of
 	// reports.
 	Annotations
+}
+
+func NewReportBatch(r *http.Request, clock Clock) (*ReportBatch, error) {
+	host, _, err := net.SplitHostPort(r.RemoteAddr)
+	if err != nil {
+		return nil, fmt.Errorf("net.SplitHostPort(%v): %v", r.RemoteAddr, err)
+	}
+
+	var reports ReportBatch
+	reports.Time = clock.Now()
+	reports.CollectorURL = *r.URL
+	reports.ClientIP = host
+	reports.ClientUserAgent = r.Header.Get("User-Agent")
+	decoder := json.NewDecoder(r.Body)
+	err = decoder.Decode(&reports.Reports)
+	if err != nil {
+		return nil, fmt.Errorf("decoder.Decode(&reports.Reports): %v", err)
+	}
+	return &reports, nil
 }
 
 // PrintBatchAsCLF prints out a summary of each report in the batch using a


### PR DESCRIPTION
The logic for taking a web request and extracting a Nel Report is
directly tied to the standard, but the pipeline is not. Isolating the
two functionalities allows the extraction logic to be used as a library
without requiring the pipeline logic.