### PR TITLE
Add buffer and fixed # of workers to Pipeline

### DIFF
--- a/pkg/collector/pipeline.go
+++ b/pkg/collector/pipeline.go
@@ -61,7 +61,8 @@ type Pipeline struct {
 	wg         *sync.WaitGroup
 }
 
-// NewPipeline creates a new Pipeline with a specified buffer size.
+// NewPipeline creates a new Pipeline with a specified buffer size
+// and number of workers.
 func NewPipeline(bufferSize int64, numWorkers int) *Pipeline {
 	return setupPipeline(context.Background(), nil, bufferSize, numWorkers)
 }
@@ -72,7 +73,7 @@ const defaultNumWorkers = 10
 // NewTestPipeline creates a new Pipeline with a specified clock.
 // This should only be used for testing.
 func NewTestPipeline(clock Clock) *Pipeline {
-	return setupPipeline(context.Background(), clock, defaultBufferSize, defaultNumWorkers)
+	return NewTestPipelineWithBuffer(clock, defaultBufferSize)
 }
 
 // NewTestPipelineWithBuffer creates a new Pipeline with a specified buffer size and clock.
@@ -168,7 +169,9 @@ func (p *Pipeline) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 // Close stops the processing, such that anything in the queue
 // gets processed, but nothing is added. It then waits until all
-// processing workers have completed.
+// processing workers have completed. All calls to ProcessReports
+// must complete before Close is called, otherwise it will cause
+// a panic.
 func (p *Pipeline) Close() {
 	close(p.c)
 	p.wg.Wait()

--- a/pkg/collector/pipeline.go
+++ b/pkg/collector/pipeline.go
@@ -106,6 +106,7 @@ func (p *Pipeline) AddProcessor(processor ReportProcessor) {
 	p.processors = append(p.processors, processor)
 }
 
+// ErrDropped is returned from ProcessReports when the queue is full and the report is dropped.
 var ErrDropped = errors.New("queue full, report dropped")
 
 // ProcessReports extracts reports from a POST upload payload, as defined by the

--- a/pkg/collector/pipeline.go
+++ b/pkg/collector/pipeline.go
@@ -52,7 +52,8 @@ var defaultClock nowClock
 // Pipeline is a series of processors that should be applied to each report that
 // the collector receives. It uses a fixed number of workers to process the reports
 // and a fixed sized queue that the workers read from. If the queue fills, reports
-// are dropped.
+// are dropped. Pipeline{} is not a usable instance, use NewPipeline for production
+// and NewTestPipeline* in tests.
 type Pipeline struct {
 	processors []ReportProcessor
 	clock      Clock

--- a/pkg/collector/pipeline_test.go
+++ b/pkg/collector/pipeline_test.go
@@ -31,7 +31,7 @@ import (
 var validNelReportPath = filepath.Clean("../pipelinetest/testdata/reports/valid-nel-report.json")
 
 func TestRespondsToOptionsRequest(t *testing.T) {
-	pipeline := collector.NewPipeline(pipelinetest.NewSimulatedClock())
+	pipeline := collector.NewTestPipeline(pipelinetest.NewSimulatedClock())
 	request := httptest.NewRequest("OPTIONS", "https://example.com/upload", bytes.NewReader([]byte("")))
 	response := httptest.NewRecorder()
 	pipeline.ServeHTTP(response, request)
@@ -50,7 +50,7 @@ func TestRespondsToOptionsRequest(t *testing.T) {
 }
 
 func TestIgnoreNonPOSTNonOPTIONS(t *testing.T) {
-	pipeline := collector.NewPipeline(pipelinetest.NewSimulatedClock())
+	pipeline := collector.NewTestPipeline(pipelinetest.NewSimulatedClock())
 	request := httptest.NewRequest("GET", "https://example.com/upload/", bytes.NewReader(testdata(validNelReportPath)))
 	request.Header.Add("Content-Type", "application/reports+json")
 	var response httptest.ResponseRecorder
@@ -62,7 +62,7 @@ func TestIgnoreNonPOSTNonOPTIONS(t *testing.T) {
 }
 
 func TestIgnoreWrongContentType(t *testing.T) {
-	pipeline := collector.NewPipeline(pipelinetest.NewSimulatedClock())
+	pipeline := collector.NewTestPipeline(pipelinetest.NewSimulatedClock())
 	request := httptest.NewRequest("POST", "https://example.com/upload/", bytes.NewReader(testdata(validNelReportPath)))
 	request.Header.Add("Content-Type", "application/json")
 	var response httptest.ResponseRecorder
@@ -74,7 +74,7 @@ func TestIgnoreWrongContentType(t *testing.T) {
 }
 
 func TestProcessReports(t *testing.T) {
-	pipeline := collector.NewPipeline(pipelinetest.NewSimulatedClock())
+	pipeline := collector.NewTestPipeline(pipelinetest.NewSimulatedClock())
 	pipeline.AddProcessor(pipelinetest.EncodeBatchAsResult{})
 	p := pipelinetest.PipelineTest{
 		TestName: "TestProcessReports",
@@ -109,7 +109,7 @@ func (g geoAnnotator) ProcessReports(ctx context.Context, batch *collector.Repor
 }
 
 func TestCustomAnnotation(t *testing.T) {
-	pipeline := collector.NewPipeline(pipelinetest.NewSimulatedClock())
+	pipeline := collector.NewTestPipeline(pipelinetest.NewSimulatedClock())
 	pipeline.AddProcessor(&geoAnnotator{})
 	pipeline.AddProcessor(pipelinetest.EncodeBatchAsResult{})
 	p := pipelinetest.PipelineTest{

--- a/pkg/collector/pipeline_test.go
+++ b/pkg/collector/pipeline_test.go
@@ -32,6 +32,7 @@ var validNelReportPath = filepath.Clean("../pipelinetest/testdata/reports/valid-
 
 func TestRespondsToOptionsRequest(t *testing.T) {
 	pipeline := collector.NewTestPipeline(pipelinetest.NewSimulatedClock())
+	defer pipeline.Close()
 	request := httptest.NewRequest("OPTIONS", "https://example.com/upload", bytes.NewReader([]byte("")))
 	response := httptest.NewRecorder()
 	pipeline.ServeHTTP(response, request)
@@ -51,6 +52,7 @@ func TestRespondsToOptionsRequest(t *testing.T) {
 
 func TestIgnoreNonPOSTNonOPTIONS(t *testing.T) {
 	pipeline := collector.NewTestPipeline(pipelinetest.NewSimulatedClock())
+	defer pipeline.Close()
 	request := httptest.NewRequest("GET", "https://example.com/upload/", bytes.NewReader(testdata(validNelReportPath)))
 	request.Header.Add("Content-Type", "application/reports+json")
 	var response httptest.ResponseRecorder
@@ -63,6 +65,7 @@ func TestIgnoreNonPOSTNonOPTIONS(t *testing.T) {
 
 func TestIgnoreWrongContentType(t *testing.T) {
 	pipeline := collector.NewTestPipeline(pipelinetest.NewSimulatedClock())
+	defer pipeline.Close()
 	request := httptest.NewRequest("POST", "https://example.com/upload/", bytes.NewReader(testdata(validNelReportPath)))
 	request.Header.Add("Content-Type", "application/json")
 	var response httptest.ResponseRecorder
@@ -75,6 +78,7 @@ func TestIgnoreWrongContentType(t *testing.T) {
 
 func TestProcessReports(t *testing.T) {
 	pipeline := collector.NewTestPipeline(pipelinetest.NewSimulatedClock())
+	defer pipeline.Close()
 	pipeline.AddProcessor(pipelinetest.EncodeBatchAsResult{})
 	p := pipelinetest.PipelineTest{
 		TestName: "TestProcessReports",
@@ -110,6 +114,7 @@ func (g geoAnnotator) ProcessReports(ctx context.Context, batch *collector.Repor
 
 func TestCustomAnnotation(t *testing.T) {
 	pipeline := collector.NewTestPipeline(pipelinetest.NewSimulatedClock())
+	defer pipeline.Close()
 	pipeline.AddProcessor(&geoAnnotator{})
 	pipeline.AddProcessor(pipelinetest.EncodeBatchAsResult{})
 	p := pipelinetest.PipelineTest{

--- a/pkg/pipelinetest/pipelinetest.go
+++ b/pkg/pipelinetest/pipelinetest.go
@@ -177,9 +177,7 @@ func (p *PipelineTest) Run(t *testing.T) {
 
 				var response httptest.ResponseRecorder
 				p.Pipeline.ProcessReports(context.Background(), &response, request)
-				log.Printf("jarls about to read from channel")
 				batch := <-c
-				log.Printf("jarls read from channel")
 				if response.Code != http.StatusNoContent {
 					t.Errorf("ProcessReports(%s:%s) got status code %d, wanted %d", payloadName, ip.tag, response.Code, http.StatusNoContent)
 					return
@@ -345,9 +343,7 @@ func newExtractReports() *extractReports {
 }
 
 func (e extractReports) ProcessReports(ctx context.Context, batch *collector.ReportBatch) {
-	log.Printf("jarls about to write to channel")
 	e.c <- batch
-	log.Printf("jarls wrote to channel")
 }
 
 func init() {


### PR DESCRIPTION
Use a fixed sized queue and a fixed number of workers to ensure that the
memory footprint cannot blow up when the pipeline is overloaded. This
ensures that requests are responded to before the processing is done,
which allows for the pipeline to shed load as needed.