### PR TITLE
Pass the HTTP header with ReportBatch

### DIFF
--- a/pkg/collector/report.go
+++ b/pkg/collector/report.go
@@ -187,6 +187,11 @@ type ReportBatch struct {
 	// The user agent of the client that uploaded the batch of reports.
 	ClientUserAgent string
 
+	// The key-value pairs of the HTTP header that is received by the collector.
+	// This can be used to get additional information. One example is to get the
+	// remote address of the client when the collector runs behind a proxy.
+	Header http.Header
+
 	// An arbitrary set of extra data that you can attach to this batch of
 	// reports.
 	Annotations
@@ -205,6 +210,7 @@ func NewReportBatch(r *http.Request, clock Clock) (*ReportBatch, error) {
 	reports.CollectorURL = *r.URL
 	reports.ClientIP = host
 	reports.ClientUserAgent = r.Header.Get("User-Agent")
+	reports.Header = r.Header
 	decoder := json.NewDecoder(r.Body)
 	err = decoder.Decode(&reports.Reports)
 	if err != nil {

--- a/pkg/collector/testdata/TestCustomAnnotation/multiple-valid-nel-reports.ipv4.json
+++ b/pkg/collector/testdata/TestCustomAnnotation/multiple-valid-nel-reports.ipv4.json
@@ -13,6 +13,11 @@
   },
   "ClientIP": "192.0.2.1",
   "ClientUserAgent": "",
+  "Header": {
+    "Content-Type": [
+      "application/reports+json"
+    ]
+  },
   "Annotations": {
     "ClientCountry": "US"
   },

--- a/pkg/collector/testdata/TestCustomAnnotation/multiple-valid-nel-reports.ipv6.json
+++ b/pkg/collector/testdata/TestCustomAnnotation/multiple-valid-nel-reports.ipv6.json
@@ -13,6 +13,11 @@
   },
   "ClientIP": "2001:db8::2",
   "ClientUserAgent": "",
+  "Header": {
+    "Content-Type": [
+      "application/reports+json"
+    ]
+  },
   "Annotations": {
     "ClientCountry": ""
   },

--- a/pkg/collector/testdata/TestCustomAnnotation/non-nel-report.ipv4.json
+++ b/pkg/collector/testdata/TestCustomAnnotation/non-nel-report.ipv4.json
@@ -13,6 +13,11 @@
   },
   "ClientIP": "192.0.2.1",
   "ClientUserAgent": "",
+  "Header": {
+    "Content-Type": [
+      "application/reports+json"
+    ]
+  },
   "Annotations": {
     "ClientCountry": "US"
   },

--- a/pkg/collector/testdata/TestCustomAnnotation/non-nel-report.ipv6.json
+++ b/pkg/collector/testdata/TestCustomAnnotation/non-nel-report.ipv6.json
@@ -13,6 +13,11 @@
   },
   "ClientIP": "2001:db8::2",
   "ClientUserAgent": "",
+  "Header": {
+    "Content-Type": [
+      "application/reports+json"
+    ]
+  },
   "Annotations": {
     "ClientCountry": ""
   },

--- a/pkg/collector/testdata/TestCustomAnnotation/valid-nel-report.ipv4.json
+++ b/pkg/collector/testdata/TestCustomAnnotation/valid-nel-report.ipv4.json
@@ -13,6 +13,11 @@
   },
   "ClientIP": "192.0.2.1",
   "ClientUserAgent": "",
+  "Header": {
+    "Content-Type": [
+      "application/reports+json"
+    ]
+  },
   "Annotations": {
     "ClientCountry": "US"
   },

--- a/pkg/collector/testdata/TestCustomAnnotation/valid-nel-report.ipv6.json
+++ b/pkg/collector/testdata/TestCustomAnnotation/valid-nel-report.ipv6.json
@@ -13,6 +13,11 @@
   },
   "ClientIP": "2001:db8::2",
   "ClientUserAgent": "",
+  "Header": {
+    "Content-Type": [
+      "application/reports+json"
+    ]
+  },
   "Annotations": {
     "ClientCountry": ""
   },

--- a/pkg/collector/testdata/TestProcessReports/multiple-valid-nel-reports.ipv4.json
+++ b/pkg/collector/testdata/TestProcessReports/multiple-valid-nel-reports.ipv4.json
@@ -13,6 +13,11 @@
   },
   "ClientIP": "192.0.2.1",
   "ClientUserAgent": "",
+  "Header": {
+    "Content-Type": [
+      "application/reports+json"
+    ]
+  },
   "Annotations": null,
   "Reports": [
     {

--- a/pkg/collector/testdata/TestProcessReports/multiple-valid-nel-reports.ipv6.json
+++ b/pkg/collector/testdata/TestProcessReports/multiple-valid-nel-reports.ipv6.json
@@ -13,6 +13,11 @@
   },
   "ClientIP": "2001:db8::2",
   "ClientUserAgent": "",
+  "Header": {
+    "Content-Type": [
+      "application/reports+json"
+    ]
+  },
   "Annotations": null,
   "Reports": [
     {

--- a/pkg/collector/testdata/TestProcessReports/non-nel-report.ipv4.json
+++ b/pkg/collector/testdata/TestProcessReports/non-nel-report.ipv4.json
@@ -13,6 +13,11 @@
   },
   "ClientIP": "192.0.2.1",
   "ClientUserAgent": "",
+  "Header": {
+    "Content-Type": [
+      "application/reports+json"
+    ]
+  },
   "Annotations": null,
   "Reports": [
     {

--- a/pkg/collector/testdata/TestProcessReports/non-nel-report.ipv6.json
+++ b/pkg/collector/testdata/TestProcessReports/non-nel-report.ipv6.json
@@ -13,6 +13,11 @@
   },
   "ClientIP": "2001:db8::2",
   "ClientUserAgent": "",
+  "Header": {
+    "Content-Type": [
+      "application/reports+json"
+    ]
+  },
   "Annotations": null,
   "Reports": [
     {

--- a/pkg/collector/testdata/TestProcessReports/valid-nel-report.ipv4.json
+++ b/pkg/collector/testdata/TestProcessReports/valid-nel-report.ipv4.json
@@ -13,6 +13,11 @@
   },
   "ClientIP": "192.0.2.1",
   "ClientUserAgent": "",
+  "Header": {
+    "Content-Type": [
+      "application/reports+json"
+    ]
+  },
   "Annotations": null,
   "Reports": [
     {

--- a/pkg/collector/testdata/TestProcessReports/valid-nel-report.ipv6.json
+++ b/pkg/collector/testdata/TestProcessReports/valid-nel-report.ipv6.json
@@ -13,6 +13,11 @@
   },
   "ClientIP": "2001:db8::2",
   "ClientUserAgent": "",
+  "Header": {
+    "Content-Type": [
+      "application/reports+json"
+    ]
+  },
   "Annotations": null,
   "Reports": [
     {

--- a/pkg/core/testdata/TestKeepNelReports/multiple-valid-nel-reports.ipv4.json
+++ b/pkg/core/testdata/TestKeepNelReports/multiple-valid-nel-reports.ipv4.json
@@ -13,6 +13,11 @@
   },
   "ClientIP": "192.0.2.1",
   "ClientUserAgent": "",
+  "Header": {
+    "Content-Type": [
+      "application/reports+json"
+    ]
+  },
   "Annotations": null,
   "Reports": [
     {

--- a/pkg/core/testdata/TestKeepNelReports/multiple-valid-nel-reports.ipv6.json
+++ b/pkg/core/testdata/TestKeepNelReports/multiple-valid-nel-reports.ipv6.json
@@ -13,6 +13,11 @@
   },
   "ClientIP": "2001:db8::2",
   "ClientUserAgent": "",
+  "Header": {
+    "Content-Type": [
+      "application/reports+json"
+    ]
+  },
   "Annotations": null,
   "Reports": [
     {

--- a/pkg/core/testdata/TestKeepNelReports/non-nel-report.ipv4.json
+++ b/pkg/core/testdata/TestKeepNelReports/non-nel-report.ipv4.json
@@ -13,6 +13,11 @@
   },
   "ClientIP": "192.0.2.1",
   "ClientUserAgent": "",
+  "Header": {
+    "Content-Type": [
+      "application/reports+json"
+    ]
+  },
   "Annotations": null,
   "Reports": []
 }

--- a/pkg/core/testdata/TestKeepNelReports/non-nel-report.ipv6.json
+++ b/pkg/core/testdata/TestKeepNelReports/non-nel-report.ipv6.json
@@ -13,6 +13,11 @@
   },
   "ClientIP": "2001:db8::2",
   "ClientUserAgent": "",
+  "Header": {
+    "Content-Type": [
+      "application/reports+json"
+    ]
+  },
   "Annotations": null,
   "Reports": []
 }

--- a/pkg/core/testdata/TestKeepNelReports/valid-nel-report.ipv4.json
+++ b/pkg/core/testdata/TestKeepNelReports/valid-nel-report.ipv4.json
@@ -13,6 +13,11 @@
   },
   "ClientIP": "192.0.2.1",
   "ClientUserAgent": "",
+  "Header": {
+    "Content-Type": [
+      "application/reports+json"
+    ]
+  },
   "Annotations": null,
   "Reports": [
     {

--- a/pkg/core/testdata/TestKeepNelReports/valid-nel-report.ipv6.json
+++ b/pkg/core/testdata/TestKeepNelReports/valid-nel-report.ipv6.json
@@ -13,6 +13,11 @@
   },
   "ClientIP": "2001:db8::2",
   "ClientUserAgent": "",
+  "Header": {
+    "Content-Type": [
+      "application/reports+json"
+    ]
+  },
   "Annotations": null,
   "Reports": [
     {


### PR DESCRIPTION
Passing the HTTP header will allow the NEL collector to extract additional information. One such example is to get the remote client address when the NEL collector is running behind a proxy.